### PR TITLE
Polish recipes UI and discovery filters

### DIFF
--- a/apps/expo-app/app/_layout.tsx
+++ b/apps/expo-app/app/_layout.tsx
@@ -1,9 +1,6 @@
-// eslint-disable-next-line import/no-duplicates
-import 'react-native-gesture-handler';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Stack, router } from 'expo-router';
 import { useEffect } from 'react';
-// eslint-disable-next-line import/no-duplicates
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { authEvents } from '@/src/core/auth/authEvents';
 import { routes } from '@/src/core/navigation/routes';
 

--- a/apps/expo-app/src/features/recipes/constants/recipeFilters.tsx
+++ b/apps/expo-app/src/features/recipes/constants/recipeFilters.tsx
@@ -1,5 +1,5 @@
 import type { FilterSection } from '@/src/shared/ui/FilterSheet';
-import { Clock3, Users } from 'lucide-react-native';
+import { Clock3, Users, Tag, MapPin } from 'lucide-react-native';
 import { theme } from '@/src/shared/theme/theme';
 import {
   RECIPE_PORTIONS_OPTIONS,
@@ -51,34 +51,50 @@ export const SAVED_FILTERS: FilterSection[] = [
 
 export const DISCOVERY_FILTERS: FilterSection[] = [
   {
-    key: 'category',
-    title: 'Category',
-    type: 'chips',
-    selectionMode: 'multi',
+    key: 'hideSaved',
+    title: 'Saved',
+    type: 'segmented',
     layout: 'row',
     options: [
-      { key: 'Beef', label: 'Beef' },
-      { key: 'Chicken', label: 'Chicken' },
-      { key: 'Dessert', label: 'Dessert' },
-      { key: 'Pasta', label: 'Pasta' },
-      { key: 'Seafood', label: 'Seafood' },
-      { key: 'Vegetarian', label: 'Vegetarian' },
+      { key: 'show', label: 'Show all' },
+      { key: 'hide', label: 'Hide saved' },
+      { key: 'saved', label: 'Saved' },
     ],
   },
   {
-    key: 'area',
-    title: 'Cuisine',
-    type: 'chips',
-    selectionMode: 'multi',
-    layout: 'row',
-    options: [
-      { key: 'American', label: 'American' },
-      { key: 'British', label: 'British' },
-      { key: 'French', label: 'French' },
-      { key: 'Indian', label: 'Indian' },
-      { key: 'Italian', label: 'Italian' },
-      { key: 'Mexican', label: 'Mexican' },
-      { key: 'Thai', label: 'Thai' },
+    key: 'discovery-pickers',
+    title: '',
+    type: 'pickerRow',
+    items: [
+      {
+        key: 'category',
+        title: 'Category',
+        placeholder: 'Any',
+        icon: <Tag color={theme.colors.primaryDark} size={20} strokeWidth={2.3} />,
+        options: [
+          { key: 'Beef', label: 'Beef' },
+          { key: 'Chicken', label: 'Chicken' },
+          { key: 'Dessert', label: 'Dessert' },
+          { key: 'Pasta', label: 'Pasta' },
+          { key: 'Seafood', label: 'Seafood' },
+          { key: 'Vegetarian', label: 'Vegetarian' },
+        ],
+      },
+      {
+        key: 'area',
+        title: 'Cuisine',
+        placeholder: 'Any',
+        icon: <MapPin color={theme.colors.primaryDark} size={20} strokeWidth={2.3} />,
+        options: [
+          { key: 'American', label: 'American' },
+          { key: 'British', label: 'British' },
+          { key: 'French', label: 'French' },
+          { key: 'Indian', label: 'Indian' },
+          { key: 'Italian', label: 'Italian' },
+          { key: 'Mexican', label: 'Mexican' },
+          { key: 'Thai', label: 'Thai' },
+        ],
+      },
     ],
   },
   {

--- a/apps/expo-app/src/features/recipes/constants/recipeUiConfig.ts
+++ b/apps/expo-app/src/features/recipes/constants/recipeUiConfig.ts
@@ -1,0 +1,1 @@
+export const RECIPE_IMAGE_FADE_MODE: 'bright' | 'dark' = 'bright';

--- a/apps/expo-app/src/features/recipes/hooks/useRecipeDiscovery.tsx
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeDiscovery.tsx
@@ -25,6 +25,11 @@ type UseRecipeDiscoveryResult = {
   canLoadMore: boolean;
 };
 
+const normalizePickerValue = (value?: string) => {
+  if (!value) return undefined;
+  return value;
+};
+
 export function useRecipeDiscovery({
   query,
   filters,
@@ -42,16 +47,16 @@ export function useRecipeDiscovery({
   const hasFilters = useMemo(() => {
     const q = query.trim();
     const ingredient = filters.ingredients?.[0];
-    const category = filters.category?.[0];
-    const area = filters.area?.[0];
+    const category = normalizePickerValue(filters.category?.[0]);
+    const area = normalizePickerValue(filters.area?.[0]);
     return Boolean(q || ingredient || category || area);
   }, [filters, query]);
 
   const params = useMemo(() => {
     const q = query.trim();
     const ingredient = filters.ingredients?.[0];
-    const category = filters.category?.[0];
-    const area = filters.area?.[0];
+    const category = normalizePickerValue(filters.category?.[0]);
+    const area = normalizePickerValue(filters.area?.[0]);
     return {
       q: q ? q : undefined,
       ingredient,

--- a/apps/expo-app/src/features/recipes/hooks/useRecipesList.tsx
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipesList.tsx
@@ -1,4 +1,3 @@
-// apps/expo-app/src/features/recipes/hooks/useRecipesList.tsx
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactElement } from 'react';
 import { RefreshControl, type RefreshControlProps } from 'react-native';

--- a/apps/expo-app/src/features/recipes/screens/EditRecipeScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/EditRecipeScreen.tsx
@@ -4,7 +4,6 @@ import { useLocalSearchParams, router } from 'expo-router';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import { Screen, ErrorText, SectionEmpty, useBottomBarActions } from '@/src/shared/ui';
 import { theme } from '@/src/shared/theme/theme';
-import { routes } from '@/src/core/navigation/routes';
 import {
   useEditRecipe,
   useRecipeEditorUiState,
@@ -59,7 +58,7 @@ export function EditRecipeScreen() {
   const onSave = useCallback(async () => {
     const ok = await saveRef.current();
     if (ok && id) {
-      router.navigate(`${routes.recipe(id)}?toast=saved`);
+      router.navigate({ pathname: '/recipes/[id]', params: { id, toast: 'saved' } });
       return;
     }
     if (ok) router.back();
@@ -135,6 +134,7 @@ export function EditRecipeScreen() {
         <RecipeSheetLayout
           hero={<RecipeHero imageUrl={form.imageUrl} />}
           heroHeight={heroHeight}
+          heroHasImage={Boolean(form.imageUrl)}
           refreshing={refreshing}
           onRefresh={onRefresh}
         >

--- a/apps/expo-app/src/features/recipes/screens/InspirationDetailsScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/InspirationDetailsScreen.tsx
@@ -13,8 +13,7 @@ import {
   useBottomBarActions,
 } from '@/src/shared/ui';
 import { theme } from '@/src/shared/theme/theme';
-import { routes } from '@/src/core/navigation/routes';
-import { useInspirationDetails } from '@/src/features/recipes/hooks';
+import { useInspirationDetails, useRecipesList } from '@/src/features/recipes/hooks';
 import {
   RecipeDetailsTabs,
   RecipeIngredientRow,
@@ -31,6 +30,7 @@ export function InspirationDetailsScreen() {
   const params = useLocalSearchParams<{ id?: string }>();
   const id = typeof params.id === 'string' ? params.id : '';
   const { recipe, isLoading, error, load, save, isSaving, saveError } = useInspirationDetails(id);
+  const saved = useRecipesList();
   const [tab, setTab] = useState<RecipeDetailsTab>('ingredients');
   const [mealType, setMealType] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -65,7 +65,7 @@ export function InspirationDetailsScreen() {
     setPickerOpen(false);
     const created = await save({ mealType });
     if (created) {
-      router.replace(`${routes.recipe(created.id)}?toast=saved`);
+      router.replace({ pathname: '/recipes/[id]', params: { id: created.id, toast: 'saved' } });
     }
   }, [mealType, save, show]);
 
@@ -106,6 +106,16 @@ export function InspirationDetailsScreen() {
       },
     ];
   }, [recipe]);
+
+  const isSaved = useMemo(() => {
+    const normalize = (value?: string | null) => (value ?? '').trim().toLowerCase();
+    const key = `${normalize(recipe?.title)}|${normalize(recipe?.imageUrl)}`;
+    if (!key.trim()) return false;
+    return saved.items.some((item) => {
+      if (!item.fromExternal) return false;
+      return `${normalize(item.title)}|${normalize(item.imageUrl)}` === key;
+    });
+  }, [recipe?.imageUrl, recipe?.title, saved.items]);
 
   const steps = useMemo(() => {
     return (recipe?.steps ?? []).filter((step) => !isStepMarker(step));
@@ -149,14 +159,22 @@ export function InspirationDetailsScreen() {
         ) : (
           <RecipeSheetLayout
             hero={
-              recipe?.imageUrl ? (
-                <Image source={{ uri: recipe.imageUrl }} style={styles.heroImage} />
-              ) : (
-                <Shimmer height={heroHeight} borderRadius={0} />
-              )
+              <View style={styles.hero}>
+                {recipe?.imageUrl ? (
+                  <Image source={{ uri: recipe.imageUrl }} style={styles.heroImage} />
+                ) : (
+                  <Shimmer height={heroHeight} borderRadius={0} />
+                )}
+                {isSaved ? (
+                  <View style={styles.savedBadge}>
+                    <Text style={styles.savedBadgeText}>Saved</Text>
+                  </View>
+                ) : null}
+              </View>
             }
             heroHeight={heroHeight}
             sheetOverlap={15}
+            heroHasImage={Boolean(recipe?.imageUrl)}
           >
             <View style={styles.summary}>
               <IconStatRow items={stats} labelStyle={styles.statLabel} rowStyle={styles.statRow} />
@@ -258,6 +276,31 @@ const styles = StyleSheet.create({
   heroImage: {
     width: '100%',
     height: 320,
+  },
+  hero: {
+    position: 'relative',
+  },
+  savedBadge: {
+    position: 'absolute',
+    top: theme.spacing.s4,
+    right: theme.spacing.s4,
+    paddingHorizontal: theme.spacing.s3,
+    paddingVertical: theme.spacing.s2,
+    borderRadius: 999,
+    backgroundColor: 'rgba(227,243,230,0.92)',
+    borderWidth: 2,
+    borderColor: theme.colors.primaryDark,
+    shadowColor: '#000',
+    shadowOpacity: 0.16,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 4,
+  },
+  savedBadgeText: {
+    color: theme.colors.primaryDark,
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.3,
   },
   summary: {
     paddingTop: theme.spacing.s3,

--- a/apps/expo-app/src/features/recipes/screens/NewRecipeScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/NewRecipeScreen.tsx
@@ -4,7 +4,6 @@ import { router } from 'expo-router';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import { Screen, ErrorText, SectionEmpty, useBottomBarActions } from '@/src/shared/ui';
 import { theme } from '@/src/shared/theme/theme';
-import { routes } from '@/src/core/navigation/routes';
 import {
   useCreateRecipe,
   useRecipeEditorUiState,
@@ -53,7 +52,9 @@ export function NewRecipeScreen() {
 
   const submit = useCallback(async () => {
     const id = await submitRef.current();
-    if (id) router.replace(`${routes.recipe(id)}?toast=saved`);
+    if (id) {
+      router.replace({ pathname: '/recipes/[id]', params: { id, toast: 'saved' } });
+    }
   }, []);
 
   const onCancel = useCallback(() => {
@@ -117,7 +118,11 @@ export function NewRecipeScreen() {
   return (
     <Screen title="Add Recipe" showBack scroll={false} contentStyle={styles.screenContent}>
       <View style={styles.root}>
-        <RecipeSheetLayout hero={<RecipeHero imageUrl={form.imageUrl} />} heroHeight={heroHeight}>
+        <RecipeSheetLayout
+          hero={<RecipeHero imageUrl={form.imageUrl} />}
+          heroHeight={heroHeight}
+          heroHasImage={Boolean(form.imageUrl)}
+        >
           <RecipeEditorShell tab={editorState.tab} onTabChange={editorState.setTab}>
             {form.serverError ? <ErrorText>{form.serverError}</ErrorText> : null}
             {editorState.tab === 'basic' ? (

--- a/apps/expo-app/src/features/recipes/screens/RecipeDetailsScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/RecipeDetailsScreen.tsx
@@ -175,7 +175,7 @@ export function RecipeDetailsScreen() {
     setIsLeaving(true);
     const ok = await remove();
     if (ok) {
-      router.replace(`${routes.recipes}?toast=deleted`);
+      router.replace({ pathname: routes.recipes, params: { toast: 'deleted' } });
       return;
     }
     setIsLeaving(false);
@@ -260,6 +260,7 @@ export function RecipeDetailsScreen() {
             }
             heroHeight={heroHeight}
             sheetOverlap={15}
+            heroHasImage={Boolean(recipe?.imageUrl)}
             refreshing={refreshing}
             onRefresh={onRefresh}
           >
@@ -408,7 +409,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: theme.spacing.s3,
     paddingVertical: theme.spacing.s2,
     borderRadius: 999,
-    backgroundColor: '#E3F3E6',
+    backgroundColor: 'rgba(227,243,230,0.8)',
     borderWidth: 2,
     borderColor: theme.colors.primaryDark,
     shadowColor: '#000',

--- a/apps/expo-app/src/features/recipes/screens/RecipesScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/RecipesScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useRecipeDiscovery,
   useRecipeListView,
@@ -60,6 +60,34 @@ export function RecipesScreen() {
   const { load: loadSaved } = saved;
   const { load: loadDiscovery } = discovery;
   const hasDiscoveryFilters = Boolean(view.query.trim() || view.activeFilterCount > 0);
+  const savedFilterMode = view.discoveryFilters.hideSaved?.[0] ?? 'show';
+
+  const savedLookup = useMemo(() => {
+    const normalize = (value?: string | null) => (value ?? '').trim().toLowerCase();
+    const keys = saved.items
+      .filter((item) => item.fromExternal)
+      .map((item) => `${normalize(item.title)}|${normalize(item.imageUrl)}`);
+    return new Set(keys);
+  }, [saved.items]);
+
+  const isDiscoverySaved = useCallback(
+    (item: InspirationListItem) => {
+      const normalize = (value?: string | null) => (value ?? '').trim().toLowerCase();
+      const key = `${normalize(item.title)}|${normalize(item.imageUrl)}`;
+      return savedLookup.has(key);
+    },
+    [savedLookup],
+  );
+
+  const visibleDiscoveryItems = useMemo(() => {
+    if (savedFilterMode === 'hide') {
+      return discovery.items.filter((item) => !isDiscoverySaved(item));
+    }
+    if (savedFilterMode === 'saved') {
+      return discovery.items.filter((item) => isDiscoverySaved(item));
+    }
+    return discovery.items;
+  }, [discovery.items, isDiscoverySaved, savedFilterMode]);
 
   useFocusEffect(
     useCallback(() => {
@@ -206,7 +234,7 @@ export function RecipesScreen() {
           <FlatList<InspirationListItem>
             key="inspiration"
             ref={discoveryListRef}
-            data={discovery.items}
+            data={visibleDiscoveryItems}
             keyExtractor={(r) => r.id}
             numColumns={1}
             showsVerticalScrollIndicator={false}
@@ -281,6 +309,7 @@ export function RecipesScreen() {
                 item={item}
                 onPress={(id) => router.push(routes.inspirationRecipe(id))}
                 onSave={handleSavePress}
+                isSaved={isDiscoverySaved(item)}
                 saveDisabled={isSaving && saveTarget?.id === item.id}
               />
             )}

--- a/apps/expo-app/src/features/recipes/ui/RecipeDiscoveryListItem.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeDiscoveryListItem.tsx
@@ -7,10 +7,17 @@ type Props = {
   item: InspirationListItem;
   onPress?: (id: string) => void;
   onSave?: (item: InspirationListItem) => void;
+  isSaved?: boolean;
   saveDisabled?: boolean;
 };
 
-export function RecipeDiscoveryListItem({ item, onPress, onSave, saveDisabled }: Props) {
+export function RecipeDiscoveryListItem({
+  item,
+  onPress,
+  onSave,
+  isSaved = false,
+  saveDisabled,
+}: Props) {
   const subtitle = [item.category, item.area].filter(Boolean).join(' · ');
   const ingredientLabel =
     item.ingredientCount !== null && item.ingredientCount !== undefined && item.ingredientCount > 0
@@ -32,8 +39,11 @@ export function RecipeDiscoveryListItem({ item, onPress, onSave, saveDisabled }:
             }
           : null
       }
-      onSave={onSave ? () => onSave(item) : undefined}
-      saveDisabled={saveDisabled}
+      onSave={!isSaved && onSave ? () => onSave(item) : undefined}
+      saveLabel={isSaved ? 'Saved' : 'Save'}
+      saveFilled={isSaved}
+      savedBadge={isSaved}
+      saveDisabled={saveDisabled || isSaved}
     />
   );
 }

--- a/apps/expo-app/src/features/recipes/ui/RecipeEditorListSection.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeEditorListSection.tsx
@@ -39,6 +39,6 @@ const styles = StyleSheet.create({
     gap: theme.spacing.s3,
   },
   listWithSticky: {
-    paddingBottom: theme.spacing.s7 + 70,
+    paddingBottom: theme.spacing.s6 + 70,
   },
 });

--- a/apps/expo-app/src/features/recipes/ui/RecipeGridCard.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeGridCard.tsx
@@ -1,9 +1,11 @@
 import type { ReactElement } from 'react';
-import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View, type ColorValue } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { Clock3, ShoppingBasket, Utensils } from 'lucide-react-native';
 import { IconStat, Shimmer } from '@/src/shared/ui';
 import { theme } from '@/src/shared/theme/theme';
 import { formatDuration } from '@/src/features/recipes/utils/formatDuration';
+import { RECIPE_IMAGE_FADE_MODE } from '@/src/features/recipes/constants/recipeUiConfig';
 
 const IMAGE_HEIGHT = 166;
 
@@ -30,6 +32,16 @@ export function RecipeGridCard({
   category,
   onPress,
 }: Props) {
+  const hasImage = Boolean(imageUrl);
+  const imageFadeColors: readonly [ColorValue, ColorValue, ColorValue, ColorValue] =
+    hasImage && RECIPE_IMAGE_FADE_MODE === 'bright'
+      ? [
+          'rgba(247,245,235,0)',
+          'rgba(247,245,235,0.18)',
+          'rgba(247,245,235,0.4)',
+          'rgba(247,245,235,0.64)',
+        ]
+      : ['rgba(0,0,0,0)', 'rgba(0,0,0,0.12)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.3)'];
   const timeLabel =
     cookingTimeMinutes !== null && cookingTimeMinutes !== undefined && cookingTimeMinutes > 0
       ? formatDuration(cookingTimeMinutes)
@@ -64,47 +76,67 @@ export function RecipeGridCard({
   ].filter((stat): stat is Stat => Boolean(stat));
 
   return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [styles.card, pressed ? styles.pressed : null]}
-    >
-      <View style={styles.imageWrap}>
-        {imageUrl ? (
-          <Image source={{ uri: imageUrl }} style={styles.image} resizeMode="cover" />
-        ) : (
-          <Shimmer height={IMAGE_HEIGHT} borderRadius={0} />
-        )}
-      </View>
+    <View style={styles.cardShadow}>
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.card, pressed ? styles.pressed : null]}
+      >
+        <View style={styles.imageWrap}>
+          {imageUrl ? (
+            <Image source={{ uri: imageUrl }} style={styles.image} resizeMode="cover" />
+          ) : (
+            <Shimmer height={IMAGE_HEIGHT} borderRadius={0} />
+          )}
+          <LinearGradient
+            colors={imageFadeColors}
+            locations={hasImage ? [0, 0.55, 0.82, 1] : [0, 0.55, 0.82, 1]}
+            start={{ x: 0.5, y: 0 }}
+            end={{ x: 0.5, y: 1 }}
+            style={styles.imageFade}
+          />
+        </View>
 
-      <View style={styles.sheet}>
-        <Text style={styles.cardTitle} numberOfLines={2} ellipsizeMode="tail">
-          {title}
-        </Text>
-
-        {stats.length ? (
-          <View style={[styles.metaRow, stats.length <= 2 ? styles.metaRowSparse : null]}>
-            {stats.map((stat) => (
-              <IconStat key={stat.key} icon={stat.icon} label={stat.label} />
-            ))}
+        <View style={styles.sheet}>
+          <View style={styles.titleWrap}>
+            <Text style={styles.cardTitle} numberOfLines={2} ellipsizeMode="tail">
+              {title}
+            </Text>
           </View>
-        ) : null}
-      </View>
-    </Pressable>
+
+          {stats.length ? (
+            <View style={[styles.metaRow, stats.length <= 2 ? styles.metaRowSparse : null]}>
+              {stats.map((stat) => (
+                <IconStat key={stat.key} icon={stat.icon} label={stat.label} />
+              ))}
+            </View>
+          ) : null}
+        </View>
+      </Pressable>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
+  cardShadow: {
     flex: 1,
-    borderRadius: 16,
-    borderWidth: 1.5,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOpacity: 0.12,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 6,
+  },
+
+  card: {
+    borderRadius: 14,
+    borderWidth: 2,
     borderColor: theme.colors.borderGreen,
     backgroundColor: theme.colors.surface,
-    marginBottom: 10,
     overflow: 'hidden',
   },
 
   imageWrap: {
+    position: 'relative',
     width: '100%',
     height: IMAGE_HEIGHT,
     backgroundColor: theme.colors.bg,
@@ -113,30 +145,40 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
+  imageFade: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 84,
+  },
 
   sheet: {
     marginTop: -16,
     paddingTop: theme.spacing.s2,
     paddingHorizontal: theme.spacing.s3,
     paddingBottom: theme.spacing.s2,
-    borderTopLeftRadius: 18,
-    borderTopRightRadius: 18,
+    borderTopLeftRadius: 26,
+    borderTopRightRadius: 26,
     backgroundColor: theme.colors.surface,
     borderTopWidth: 1,
-    borderLeftWidth: 1,
-    borderRightWidth: 1,
+    borderLeftWidth: 0,
+    borderRightWidth: 0,
     borderColor: 'rgba(198,192,168,0.6)',
     minHeight: 80,
   },
 
   cardTitle: {
-    marginTop: 4,
     color: theme.colors.text,
-    fontSize: 18,
+    fontSize: 17,
     fontWeight: '600',
     lineHeight: 22,
     textAlign: 'center',
-    minHeight: 40,
+  },
+  titleWrap: {
+    height: 44,
+    justifyContent: 'center',
+    marginTop: 4,
   },
 
   metaRow: {

--- a/apps/expo-app/src/features/recipes/ui/RecipeListCard.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeListCard.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react';
-import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View, type ColorValue } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { Bookmark } from 'lucide-react-native';
 import { IconStat, Shimmer } from '@/src/shared/ui';
 import { theme } from '@/src/shared/theme/theme';
+import { RECIPE_IMAGE_FADE_MODE } from '@/src/features/recipes/constants/recipeUiConfig';
 
 type MetaStat = {
   icon: ReactNode;
@@ -18,7 +20,9 @@ type Props = {
   metaMiddle?: MetaStat | null;
   onSave?: () => void;
   saveLabel?: string;
+  saveFilled?: boolean;
   saveDisabled?: boolean;
+  savedBadge?: boolean;
 };
 
 export function RecipeListCard({
@@ -30,71 +34,123 @@ export function RecipeListCard({
   metaMiddle,
   onSave,
   saveLabel = 'Save',
+  saveFilled = false,
   saveDisabled = false,
+  savedBadge = false,
 }: Props) {
   const leftMeta = metaLeft ?? null;
   const middleMeta = metaMiddle ?? null;
+  const hasImage = Boolean(imageUrl);
+  const imageFadeColors: readonly [ColorValue, ColorValue, ColorValue, ColorValue] =
+    hasImage && RECIPE_IMAGE_FADE_MODE === 'bright'
+      ? [
+          'rgba(247,245,235,0)',
+          'rgba(247,245,235,0.14)',
+          'rgba(247,245,235,0.28)',
+          'rgba(247,245,235,0.42)',
+        ]
+      : ['rgba(0,0,0,0)', 'rgba(0,0,0,0.12)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.3)'];
 
   return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [styles.card, pressed ? styles.pressed : null]}
-    >
-      <View style={styles.imageFrame}>
-        {imageUrl ? (
-          <Image source={{ uri: imageUrl }} style={styles.image} resizeMode="cover" />
-        ) : (
-          <Shimmer height={96} borderRadius={16} />
-        )}
-      </View>
-
-      <View style={styles.content}>
-        <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
-          {title}
-        </Text>
-
-        <Text style={styles.subtitle} numberOfLines={1}>
-          {subtitle}
-        </Text>
-
-        <View style={styles.metaRow}>
-          {leftMeta ? <IconStat icon={leftMeta.icon} label={leftMeta.label} /> : null}
-          {middleMeta ? <IconStat icon={middleMeta.icon} label={middleMeta.label} /> : null}
-          {onSave ? (
-            <Pressable
-              style={({ pressed }) => [
-                styles.saveWrap,
-                pressed ? styles.savePressed : null,
-                saveDisabled ? styles.saveDisabled : null,
-              ]}
-              onPress={onSave}
-              disabled={saveDisabled}
-            >
-              <IconStat
-                icon={<Bookmark color={theme.colors.primaryDark} size={26} strokeWidth={2.4} />}
-                label={saveLabel}
-              />
-            </Pressable>
+    <View style={styles.cardShadow}>
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.card, pressed ? styles.pressed : null]}
+      >
+        <View style={styles.imageFrame}>
+          {imageUrl ? (
+            <Image source={{ uri: imageUrl }} style={styles.image} resizeMode="cover" />
           ) : (
-            <View style={styles.saveWrap}>
-              <IconStat
-                icon={<Bookmark color={theme.colors.primaryDark} size={26} strokeWidth={2.4} />}
-                label={saveLabel}
-              />
-            </View>
+            <Shimmer height={108} borderRadius={16} />
           )}
+          {savedBadge ? (
+            <View style={styles.savedBadge}>
+              <Text style={styles.savedBadgeText}>Saved</Text>
+            </View>
+          ) : null}
+          {hasImage ? (
+            <LinearGradient
+              colors={imageFadeColors}
+              locations={[0, 0.58, 0.82, 1]}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={styles.imageFade}
+            />
+          ) : null}
         </View>
-      </View>
-    </Pressable>
+
+        <View style={styles.content}>
+          <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+            {title}
+          </Text>
+
+          <Text style={styles.subtitle} numberOfLines={1}>
+            {subtitle}
+          </Text>
+
+          <View style={styles.metaRow}>
+            {leftMeta ? <IconStat icon={leftMeta.icon} label={leftMeta.label} /> : null}
+            {middleMeta ? <IconStat icon={middleMeta.icon} label={middleMeta.label} /> : null}
+            {onSave ? (
+              <Pressable
+                style={({ pressed }) => [
+                  styles.saveWrap,
+                  pressed ? styles.savePressed : null,
+                  saveDisabled ? styles.saveDisabled : null,
+                ]}
+                onPress={onSave}
+                disabled={saveDisabled}
+              >
+                <IconStat
+                  icon={
+                    <Bookmark
+                      color={theme.colors.primaryDark}
+                      fill={saveFilled ? theme.colors.primaryDark : 'transparent'}
+                      size={26}
+                      strokeWidth={2.4}
+                    />
+                  }
+                  label={saveLabel}
+                  labelStyle={saveFilled ? styles.saveLabelSaved : undefined}
+                />
+              </Pressable>
+            ) : (
+              <View style={styles.saveWrap}>
+                <IconStat
+                  icon={
+                    <Bookmark
+                      color={theme.colors.primaryDark}
+                      fill={saveFilled ? theme.colors.primary : 'transparent'}
+                      size={26}
+                      strokeWidth={2.4}
+                    />
+                  }
+                  label={saveLabel}
+                  labelStyle={saveFilled ? styles.saveLabelSaved : undefined}
+                />
+              </View>
+            )}
+          </View>
+        </View>
+      </Pressable>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  cardShadow: {
+    marginBottom: 10,
+    borderRadius: 18,
+    shadowColor: '#000',
+    shadowOpacity: 0.16,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 8,
+  },
   card: {
     flexDirection: 'row',
     gap: theme.spacing.s3,
     padding: theme.spacing.s3,
-    marginBottom: theme.spacing.s3,
     borderRadius: 18,
     borderWidth: 1.5,
     borderColor: theme.colors.borderGreen,
@@ -102,6 +158,7 @@ const styles = StyleSheet.create({
   },
 
   imageFrame: {
+    position: 'relative',
     width: 118,
     borderRadius: 16,
     borderWidth: 2,
@@ -111,7 +168,14 @@ const styles = StyleSheet.create({
   },
   image: {
     width: '100%',
-    height: 96,
+    height: 108,
+  },
+  imageFade: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 14,
   },
 
   content: {
@@ -150,8 +214,28 @@ const styles = StyleSheet.create({
   saveDisabled: {
     opacity: 0.45,
   },
+  saveLabelSaved: {
+    color: theme.colors.primaryDark,
+  },
 
   pressed: {
     opacity: 0.9,
+  },
+  savedBadge: {
+    position: 'absolute',
+    top: theme.spacing.s2,
+    right: theme.spacing.s2,
+    paddingHorizontal: theme.spacing.s2,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(227,243,230,0.92)',
+    borderWidth: 1.5,
+    borderColor: theme.colors.primaryDark,
+  },
+  savedBadgeText: {
+    fontSize: 10,
+    fontWeight: '800',
+    color: theme.colors.primaryDark,
+    letterSpacing: 0.3,
   },
 });

--- a/apps/expo-app/src/features/recipes/ui/RecipeSheetLayout.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeSheetLayout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { Animated, RefreshControl, StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { theme } from '@/src/shared/theme/theme';
+import { RECIPE_IMAGE_FADE_MODE } from '@/src/features/recipes/constants/recipeUiConfig';
 
 type Props = {
   hero: ReactNode;
@@ -10,6 +11,7 @@ type Props = {
   children: ReactNode;
   sheetOverlap?: number;
   heroBleed?: number;
+  heroHasImage?: boolean;
   refreshing?: boolean;
   onRefresh?: () => void | Promise<void>;
 };
@@ -20,6 +22,7 @@ export function RecipeSheetLayout({
   children,
   sheetOverlap = 63,
   heroBleed = 0,
+  heroHasImage = false,
   refreshing = false,
   onRefresh,
 }: Props) {
@@ -71,11 +74,15 @@ export function RecipeSheetLayout({
       >
         {hero}
         <LinearGradient
-          colors={['rgba(0,0,0,0)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.32)']}
+          colors={
+            heroHasImage && RECIPE_IMAGE_FADE_MODE === 'bright'
+              ? ['rgba(247,245,235,0)', 'rgba(247,245,235,0.52)', 'rgba(247,245,235,0.82)']
+              : ['rgba(0,0,0,0)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.32)']
+          }
           locations={[0, 0.6, 1]}
           start={{ x: 0.5, y: 0 }}
           end={{ x: 0.5, y: 1 }}
-          style={[styles.heroFade, { bottom: -87 + heroBleed, height: 220 + heroBleed }]}
+          style={[styles.heroFade, { bottom: -87 + heroBleed, height: 198 + heroBleed }]}
         />
       </Animated.View>
 

--- a/apps/expo-app/src/shared/ui/FilterSheet/FilterSheet.tsx
+++ b/apps/expo-app/src/shared/ui/FilterSheet/FilterSheet.tsx
@@ -8,6 +8,7 @@ import { PickerSheet } from '@/src/shared/ui/PickerSheet';
 import { Chip } from '@/src/shared/ui/Chip';
 import { ModalSheet } from '@/src/shared/ui/ModalSheet';
 import { TextField } from '@/src/shared/ui/TextField';
+import { SegmentedTabs } from '@/src/shared/ui/SegmentedTabs';
 
 export type FilterOption = {
   key: string;
@@ -17,7 +18,7 @@ export type FilterOption = {
 export type FilterSection = {
   key: string;
   title: string;
-  type: 'chips' | 'picker' | 'tags' | 'pickerRow';
+  type: 'chips' | 'picker' | 'tags' | 'pickerRow' | 'segmented';
   options?: FilterOption[];
   selectionMode?: 'single' | 'multi';
   placeholder?: string;
@@ -150,6 +151,8 @@ export function FilterSheet({
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.sections}>
         {sections.map((section) => {
           const selected = selectedMap[section.key] ?? new Set<string>();
+          const segmentedDefault = section.options?.[0]?.key ?? '';
+          const segmentedValue = selection[section.key]?.[0] ?? segmentedDefault;
 
           return (
             <View
@@ -159,7 +162,16 @@ export function FilterSheet({
                 section.type === 'picker' && section.layout === 'row' ? styles.sectionInline : null,
               ]}
             >
-              {section.title ? <Text style={styles.sectionTitle}>{section.title}</Text> : null}
+              {section.title && section.type !== 'segmented' ? (
+                <Text style={styles.sectionTitle}>{section.title}</Text>
+              ) : null}
+              {section.type === 'segmented' && section.options ? (
+                <SegmentedTabs
+                  tabs={section.options.map((opt) => ({ key: opt.key, label: opt.label }))}
+                  value={segmentedValue}
+                  onChange={(key) => onUpdateSelection(section.key, [key])}
+                />
+              ) : null}
               {section.type === 'chips' ? (
                 <View style={[styles.options, section.layout === 'row' ? styles.optionsRow : null]}>
                   {(section.options ?? []).map((opt) =>

--- a/apps/expo-app/src/shared/ui/Screen/Screen.tsx
+++ b/apps/expo-app/src/shared/ui/Screen/Screen.tsx
@@ -1,4 +1,3 @@
-// apps/expo-app/src/shared/ui/Screen/Screen.tsx
 import type { ReactElement, ReactNode } from 'react';
 import {
   ScrollView,

--- a/apps/expo-app/src/shared/ui/SegmentedTabs/SegmentedTabs.tsx
+++ b/apps/expo-app/src/shared/ui/SegmentedTabs/SegmentedTabs.tsx
@@ -37,12 +37,11 @@ export function SegmentedTabs({ tabs, value, onChange }: Props) {
 const styles = StyleSheet.create({
   wrap: {
     flexDirection: 'row',
-    gap: 8,
-    padding: 6,
+    gap: 6,
+    padding: 4,
     borderRadius: theme.radius.pill,
-    borderWidth: 1,
-    borderColor: theme.colors.borderNeutral,
-    backgroundColor: theme.colors.bgLight,
+    backgroundColor: theme.colors.primaryLight,
+    marginBottom: 10,
   },
   tab: {
     flex: 1,
@@ -55,20 +54,20 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   tabActive: {
-    backgroundColor: theme.colors.surface,
-    borderWidth: 1,
-    borderColor: theme.colors.borderNeutral,
+    backgroundColor: theme.colors.primary,
   },
   text: {
-    fontSize: 12,
-    fontWeight: '900',
+    fontSize: 14,
+    fontWeight: '800',
     letterSpacing: 0.2,
   },
   textInactive: {
-    color: theme.colors.textMuted,
+    color: theme.colors.primaryDark,
+    opacity: 0.8,
   },
   textActive: {
-    color: theme.colors.text,
+    color: theme.colors.textOnPrimary,
+    fontSize: 15,
   },
   pressed: {
     opacity: 0.9,

--- a/services/app-api/src/main/java/com/mealflow/appapi/inspiration/service/InspirationService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/inspiration/service/InspirationService.java
@@ -21,6 +21,7 @@ public class InspirationService {
 
     public List<MealDbMeal> list(String query, String ingredient, String category, String area, Integer limit) {
         List<MealDbMeal> meals;
+        boolean noFilters = false;
         if (StringUtils.hasText(query)) {
             meals = mealDbClient.searchByName(query.trim());
         } else if (StringUtils.hasText(ingredient)) {
@@ -30,10 +31,15 @@ public class InspirationService {
         } else if (StringUtils.hasText(area)) {
             meals = mealDbClient.filterByArea(area.trim());
         } else {
+            noFilters = true;
             meals = mealDbClient.searchByName("");
         }
 
         int capped = resolveLimit(limit);
+        if (noFilters) {
+            meals = new java.util.ArrayList<>(meals);
+            java.util.Collections.shuffle(meals);
+        }
         if (meals.size() <= capped) {
             return meals;
         }

--- a/services/app-api/src/main/java/com/mealflow/appapi/inspiration/web/mapper/InspirationMapper.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/inspiration/web/mapper/InspirationMapper.java
@@ -29,84 +29,87 @@ public class InspirationMapper {
     }
 
     private List<InspirationIngredientResponse> toIngredients(MealDbMeal meal) {
-        List<String> names = List.of(
-                meal.ingredient1(),
-                meal.ingredient2(),
-                meal.ingredient3(),
-                meal.ingredient4(),
-                meal.ingredient5(),
-                meal.ingredient6(),
-                meal.ingredient7(),
-                meal.ingredient8(),
-                meal.ingredient9(),
-                meal.ingredient10(),
-                meal.ingredient11(),
-                meal.ingredient12(),
-                meal.ingredient13(),
-                meal.ingredient14(),
-                meal.ingredient15(),
-                meal.ingredient16(),
-                meal.ingredient17(),
-                meal.ingredient18(),
-                meal.ingredient19(),
-                meal.ingredient20());
+        String[] names = {
+            meal.ingredient1(),
+            meal.ingredient2(),
+            meal.ingredient3(),
+            meal.ingredient4(),
+            meal.ingredient5(),
+            meal.ingredient6(),
+            meal.ingredient7(),
+            meal.ingredient8(),
+            meal.ingredient9(),
+            meal.ingredient10(),
+            meal.ingredient11(),
+            meal.ingredient12(),
+            meal.ingredient13(),
+            meal.ingredient14(),
+            meal.ingredient15(),
+            meal.ingredient16(),
+            meal.ingredient17(),
+            meal.ingredient18(),
+            meal.ingredient19(),
+            meal.ingredient20()
+        };
 
-        List<String> measures = List.of(
-                meal.measure1(),
-                meal.measure2(),
-                meal.measure3(),
-                meal.measure4(),
-                meal.measure5(),
-                meal.measure6(),
-                meal.measure7(),
-                meal.measure8(),
-                meal.measure9(),
-                meal.measure10(),
-                meal.measure11(),
-                meal.measure12(),
-                meal.measure13(),
-                meal.measure14(),
-                meal.measure15(),
-                meal.measure16(),
-                meal.measure17(),
-                meal.measure18(),
-                meal.measure19(),
-                meal.measure20());
+        String[] measures = {
+            meal.measure1(),
+            meal.measure2(),
+            meal.measure3(),
+            meal.measure4(),
+            meal.measure5(),
+            meal.measure6(),
+            meal.measure7(),
+            meal.measure8(),
+            meal.measure9(),
+            meal.measure10(),
+            meal.measure11(),
+            meal.measure12(),
+            meal.measure13(),
+            meal.measure14(),
+            meal.measure15(),
+            meal.measure16(),
+            meal.measure17(),
+            meal.measure18(),
+            meal.measure19(),
+            meal.measure20()
+        };
 
         List<InspirationIngredientResponse> result = new ArrayList<>();
-        for (int i = 0; i < names.size(); i++) {
-            String name = trimToNull(names.get(i));
+        for (int i = 0; i < names.length; i++) {
+            String name = trimToNull(names[i]);
             if (name == null) {
                 continue;
             }
-            String measure = trimToNull(measures.get(i));
+            String measure = trimToNull(measures[i]);
             result.add(new InspirationIngredientResponse(name, measure));
         }
         return result;
     }
 
     private Integer countIngredients(MealDbMeal meal) {
-        List<String> names = List.of(
-                meal.ingredient1(),
-                meal.ingredient2(),
-                meal.ingredient3(),
-                meal.ingredient4(),
-                meal.ingredient5(),
-                meal.ingredient6(),
-                meal.ingredient7(),
-                meal.ingredient8(),
-                meal.ingredient9(),
-                meal.ingredient10(),
-                meal.ingredient11(),
-                meal.ingredient12(),
-                meal.ingredient13(),
-                meal.ingredient14(),
-                meal.ingredient15(),
-                meal.ingredient16(),
-                meal.ingredient17(),
-                meal.ingredient18(),
-                meal.ingredient19(),
-                meal.ingredient20());
+        String[] names = {
+            meal.ingredient1(),
+            meal.ingredient2(),
+            meal.ingredient3(),
+            meal.ingredient4(),
+            meal.ingredient5(),
+            meal.ingredient6(),
+            meal.ingredient7(),
+            meal.ingredient8(),
+            meal.ingredient9(),
+            meal.ingredient10(),
+            meal.ingredient11(),
+            meal.ingredient12(),
+            meal.ingredient13(),
+            meal.ingredient14(),
+            meal.ingredient15(),
+            meal.ingredient16(),
+            meal.ingredient17(),
+            meal.ingredient18(),
+            meal.ingredient19(),
+            meal.ingredient20()
+        };
 
         int count = 0;
         for (String name : names) {

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/repository/RecipeRepository.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/repository/RecipeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface RecipeRepository extends MongoRepository<Recipe, String> {
 
-    List<Recipe> findAllByUserId(String userId);
+    List<Recipe> findAllByUserIdOrderByCreatedAtDesc(String userId);
 
     Optional<Recipe> findByIdAndUserId(String id, String userId);
 

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/service/RecipeService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/service/RecipeService.java
@@ -20,7 +20,7 @@ public class RecipeService {
     }
 
     public List<Recipe> listForUser(String userId) {
-        return recipeRepository.findAllByUserId(userId);
+        return recipeRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
     }
 
     public Recipe getForUser(String userId, String recipeId) {


### PR DESCRIPTION
## Summary
- Polish recipe cards (grid + list) with refined fades, shadows, consistent title heights, and saved badges.
- Improve discovery filtering UI with segmented saved tabs and picker-style selectors.
- Adjust external recipe handling to better flag saved items and improve list behavior.
- Backend: sort saved recipes newest-first and shuffle inspiration list safely.

## Changes
- UI: card fade/shadow tuning, saved badge styling, and consistent card heights across grid/list.
- UI: new `recipeUiConfig` toggle for image fade mode.
- UI: discovery filter sheet updated to segmented tabs + picker rows with icons.
- UI: saved detection for external recipes with “Saved” badge on details.
- Backend: `RecipeRepository` + `RecipeService` sort saved recipes newest-first.
- Backend: copy before shuffle in `InspirationService` to avoid immutable list errors.
