### PR TITLE
feat(extraction): estimate missing ingredient amounts

### DIFF
--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
@@ -32,10 +32,11 @@ public class LlmRecipeExtractor {
             - All quantities MUST use the %s system.
               - metric units to use: g, kg, ml, dl, l, msk (tablespoon), tsk (teaspoon), st (piece)
               - imperial units to use: oz, lb, tsp, tbsp, cup, fl oz
-            - If a quantity or unit is not stated, set them to null and add the corresponding ingredient name (or 'cookingTimeMinutes', 'portions') to uncertainFields.
-            - Do not invent values you cannot infer. Prefer null over guessing.
+            - If a quantity or unit is not stated in the source, ESTIMATE a sensible value from the dish, the cooking steps, and standard recipes for this kind of food, scaled to the portion count. Use common, rounded amounts a home cook expects (e.g. 2 dl, 1 msk, 1 st).
+            - Every value you ESTIMATED rather than read directly from the source MUST be listed in uncertainFields, by ingredient name (or 'cookingTimeMinutes' / 'portions'), so the user can review and confirm.
+            - Only leave a quantity or unit null if you genuinely cannot make a reasonable estimate even after considering the dish and steps.
             - cookingTimeMinutes: total active + passive minutes, integer. null if unknown.
-            - portions: integer count. null if unknown.
+            - portions: integer count. If not stated, assume 4, set portions to 4, and add 'portions' to uncertainFields. Scale all estimated ingredient amounts to this portion count.
             - title: short and descriptive, max 80 chars. No emoji.
             - steps: ordered list of plain-text instructions, max 15 steps, each max 400 chars. No numbering prefixes.
             - category: one of "breakfast", "lunch", "dinner", "dessert", "snack", "drink", "side", "other". null if unknown.


### PR DESCRIPTION
## Summary

When a quantity/unit is **not stated** in the source video or photo, the recipe extractor used to set it to `null` and flag it. This changes the LLM instruction so it instead **estimates a sensible, rounded amount** (e.g. `2 dl`, `1 msk`, `1 st`) from the dish, the cooking steps, and standard recipes — scaled to the portion count.

Every estimated value is still added to `uncertainFields`, so the **existing review screen** prompts the user to confirm before saving. When `portions` is unstated, the model assumes 4 (flagged) and scales estimates to that count — portions is the main correctness lever, since all amounts scale off it.

## Scope

- **Prompt-only.** A single edit to `LlmRecipeExtractor.SYSTEM_PROMPT`. No changes to `RecipeDraft`, DTOs, the mapper, the API contract, or the frontend.
- `parse()` is unchanged; `LlmRecipeExtractorTest` still passes.

## Cost

Negligible. It rides on the same single vision call that already dominates cost (image/frame input tokens). It only fills `quantity`/`unit` fields that were already part of the output shape — a handful of extra output tokens per recipe, no extra request, no meaningful latency.

## Follow-up (not in this PR)

If estimate quality holds up in practice, a good next step is a per-ingredient `estimated` flag surfaced in the review UI (e.g. a `~` prefix), so users can visually tell estimated values from values read directly from the source. Deliberately left out here to validate quality cheaply first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)