### PR TITLE
feat(extraction): translate recipe into the user's chosen app language

### DIFF
--- a/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import * as ImagePicker from 'expo-image-picker';
 import { extractionApi } from '@/src/features/recipes/api/extractionApi';
 import type { ExtractionJob, ExtractionStatus } from '@/src/features/recipes/types';
@@ -32,18 +33,6 @@ export type RecipeExtractionActions = {
   reset: () => void;
 };
 
-function detectLocale(): string {
-  try {
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      const tag = Intl.DateTimeFormat().resolvedOptions().locale;
-      if (tag) return tag;
-    }
-  } catch {
-    // ignore
-  }
-  return 'en-US';
-}
-
 function isTerminal(status: ExtractionStatus): boolean {
   return status === 'READY' || status === 'FAILED' || status === 'ACCEPTED';
 }
@@ -53,6 +42,7 @@ export function useRecipeExtraction(): {
   actions: RecipeExtractionActions;
 } {
   const { showError } = useGlobalToast();
+  const { i18n } = useTranslation();
   const [phase, setPhase] = useState<Phase>('idle');
   const [job, setJob] = useState<ExtractionJob | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -112,7 +102,9 @@ export function useRecipeExtraction(): {
       setPhase('uploading');
       cancelledRef.current = false;
       try {
-        const created = await extractionApi.start(formData, detectLocale());
+        // Send the user's active app language (auto-detected or manually overridden in Settings)
+        // so the extracted recipe is translated to the same language as the rest of the UI.
+        const created = await extractionApi.start(formData, i18n.language);
         if (cancelledRef.current) return;
         setJob(created);
         setPhase('processing');
@@ -127,7 +119,7 @@ export function useRecipeExtraction(): {
         showError({ kind: uiErr.kind, message });
       }
     },
-    [beginPolling, showError],
+    [beginPolling, showError, i18n],
   );
 
   const buildFormData = useCallback((uri: string, fileName: string, mimeType: string): FormData => {


### PR DESCRIPTION
## Summary

The recipe extractor already translates an extracted recipe into a target language (the prompt instructs it to). But `useRecipeExtraction` sent the **device OS locale** (`Intl.DateTimeFormat().resolvedOptions().locale`) as that target. That ignores a manual language override in Settings — a user on an English phone who picks **Swedish** would get an **English** recipe, out of step with the rest of the localized UI.

This sends `i18n.language` — the active, resolved app language (auto-detected *or* manually overridden) — instead. So an English TikTok/photo yields a Swedish recipe when the app is set to Swedish, and vice versa.

## Scope & cost

- Frontend-only: a one-line change in `useRecipeExtraction` (plus removing the now-unused `detectLocale` helper). No backend, DTO, or API-contract change — the backend already resolves `sv` → Swedish / else English.
- **Zero extra cost.** The translation already happens inside the same single vision call; this only changes *which* language code is sent. No extra tokens, request, or latency.

## Verification

- `tsc --noEmit`: error count unchanged from the pre-existing baseline (the two errors now shown in this file are the pre-existing `MediaTypeOptions` ones, just at shifted line numbers).
- `eslint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)