### PR TITLE
feat(extraction): subtly flag estimated ingredient amounts in review

### DIFF
--- a/apps/expo-app/src/features/recipes/hooks/useExtractionReview.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useExtractionReview.ts
@@ -82,6 +82,7 @@ export function useExtractionReview(jobId: string | undefined): ExtractionReview
           name: ing.name,
           quantity: ing.quantity ?? null,
           unit: ing.unit ?? null,
+          estimated: ing.estimated ?? false,
         })),
       );
       setSteps(draft.steps ?? []);
@@ -115,7 +116,7 @@ export function useExtractionReview(jobId: string | undefined): ExtractionReview
       const base = form.getApiValues();
       const cleanIngredients = ingredients
         .filter((ing) => ing.name && ing.name.trim().length > 0)
-        .map(({ id: _id, ...rest }) => rest);
+        .map(({ id: _id, estimated: _estimated, ...rest }) => rest);
       const cleanSteps = steps.filter((s) => s.trim().length > 0);
       const created = await extractionApi.accept(jobId, {
         title: base.title,

--- a/apps/expo-app/src/features/recipes/types.ts
+++ b/apps/expo-app/src/features/recipes/types.ts
@@ -3,6 +3,8 @@ export type IngredientDto = {
   name: string;
   quantity?: number | null;
   unit?: string | null;
+  /** Review-only hint: the amount/unit was estimated by extraction, not read from the source. */
+  estimated?: boolean | null;
 };
 
 export type RecipeListItem = {
@@ -95,6 +97,7 @@ export type ExtractionDraftIngredient = {
   name: string;
   quantity?: number | null;
   unit?: string | null;
+  estimated?: boolean | null;
 };
 
 export type ExtractionDraft = {

--- a/apps/expo-app/src/features/recipes/ui/RecipeEditorRenderers.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeEditorRenderers.tsx
@@ -25,6 +25,7 @@ export function createRecipeEditorRenderers({ onEditIngredient, onEditStep }: Ar
           name={item.name}
           quantity={item.quantity}
           unit={item.unit}
+          estimated={item.estimated}
           onDrag={drag}
         />
       </Pressable>

--- a/apps/expo-app/src/features/recipes/ui/RecipeIngredientRow.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeIngredientRow.tsx
@@ -7,6 +7,8 @@ type Props = {
   amount?: string;
   quantity?: number | null;
   unit?: string | null;
+  /** When true, the amount was estimated by extraction; shown with a subtle "~" prefix. */
+  estimated?: boolean | null;
   onDrag?: () => void;
   showHandle?: boolean;
 };
@@ -16,6 +18,7 @@ export function RecipeIngredientRow({
   amount,
   quantity,
   unit,
+  estimated = false,
   onDrag,
   showHandle = false,
 }: Props) {
@@ -23,6 +26,7 @@ export function RecipeIngredientRow({
   const styles = useThemedStyles(createStyles);
   const hasHandle = Boolean(onDrag) || showHandle;
   const derivedAmount = amount ?? formatAmount(quantity, unit);
+  const amountText = derivedAmount && estimated ? `~${derivedAmount}` : derivedAmount;
 
   return (
     <View style={styles.row}>
@@ -31,7 +35,7 @@ export function RecipeIngredientRow({
       </View>
       <Text style={styles.name} numberOfLines={1}>
         {name}
-        {derivedAmount ? <Text style={styles.amountInline}>{` | ${derivedAmount}`}</Text> : null}
+        {amountText ? <Text style={styles.amountInline}>{` | ${amountText}`}</Text> : null}
       </Text>
       {hasHandle ? (
         onDrag ? (

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/domain/RecipeDraft.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/domain/RecipeDraft.java
@@ -93,13 +93,19 @@ public class RecipeDraft {
         private String name;
         private Double quantity;
         private String unit;
+        private boolean estimated;
 
         public DraftIngredient() {}
 
         public DraftIngredient(String name, Double quantity, String unit) {
+            this(name, quantity, unit, false);
+        }
+
+        public DraftIngredient(String name, Double quantity, String unit, boolean estimated) {
             this.name = name;
             this.quantity = quantity;
             this.unit = unit;
+            this.estimated = estimated;
         }
 
         public String getName() {
@@ -124,6 +130,14 @@ public class RecipeDraft {
 
         public void setUnit(String unit) {
             this.unit = unit;
+        }
+
+        public boolean isEstimated() {
+            return estimated;
+        }
+
+        public void setEstimated(boolean estimated) {
+            this.estimated = estimated;
         }
     }
 }

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
@@ -34,6 +34,7 @@ public class LlmRecipeExtractor {
               - imperial units to use: oz, lb, tsp, tbsp, cup, fl oz
             - If a quantity or unit is not stated in the source, ESTIMATE a sensible value from the dish, the cooking steps, and standard recipes for this kind of food, scaled to the portion count. Use common, rounded amounts a home cook expects (e.g. 2 dl, 1 msk, 1 st).
             - Every value you ESTIMATED rather than read directly from the source MUST be listed in uncertainFields, by ingredient name (or 'cookingTimeMinutes' / 'portions'), so the user can review and confirm.
+            - For each ingredient, set "estimated" to true when you estimated its quantity or unit rather than reading it from the source; otherwise false.
             - Only leave a quantity or unit null if you genuinely cannot make a reasonable estimate even after considering the dish and steps.
             - cookingTimeMinutes: total active + passive minutes, integer. null if unknown.
             - portions: integer count. If not stated, assume 4, set portions to 4, and add 'portions' to uncertainFields. Scale all estimated ingredient amounts to this portion count.
@@ -47,7 +48,7 @@ public class LlmRecipeExtractor {
             {
               "title": string,
               "description": string|null,
-              "ingredients": [{"name": string, "quantity": number|null, "unit": string|null}],
+              "ingredients": [{"name": string, "quantity": number|null, "unit": string|null, "estimated": boolean}],
               "steps": [string],
               "cookingTimeMinutes": number|null,
               "portions": number|null,
@@ -119,7 +120,8 @@ public class LlmRecipeExtractor {
                     }
                     Double quantity = doubleOrNull(node.path("quantity"));
                     String unit = textOrNull(node.path("unit"));
-                    ingredients.add(new RecipeDraft.DraftIngredient(name.trim(), quantity, unit));
+                    boolean estimated = node.path("estimated").asBoolean(false);
+                    ingredients.add(new RecipeDraft.DraftIngredient(name.trim(), quantity, unit, estimated));
                 }
             }
             draft.setIngredients(ingredients);

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionMapper.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionMapper.java
@@ -31,7 +31,8 @@ public class ExtractionMapper {
 
     private ExtractionDraftResponse toDraftResponse(RecipeDraft draft) {
         List<ExtractionDraftResponse.DraftIngredientDto> ingredients = draft.getIngredients().stream()
-                .map(i -> new ExtractionDraftResponse.DraftIngredientDto(i.getName(), i.getQuantity(), i.getUnit()))
+                .map(i -> new ExtractionDraftResponse.DraftIngredientDto(
+                        i.getName(), i.getQuantity(), i.getUnit(), i.isEstimated()))
                 .toList();
         return new ExtractionDraftResponse(
                 draft.getTitle(),

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/ExtractionDraftResponse.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/ExtractionDraftResponse.java
@@ -13,5 +13,5 @@ public record ExtractionDraftResponse(
         String language,
         List<String> uncertainFields) {
 
-    public record DraftIngredientDto(String name, Double quantity, String unit) {}
+    public record DraftIngredientDto(String name, Double quantity, String unit, boolean estimated) {}
 }


### PR DESCRIPTION
## Summary

Step 2 of the amount-estimation work (#45). The extractor already estimates missing ingredient amounts; this makes the **review screen show which amounts were guessed** so users can tell estimates from values read directly from the source.

Each ingredient now carries an `estimated` flag end-to-end. In the review list, estimated amounts get a **subtle `~` prefix** — e.g. `Cream | ~2 dl` — in the same muted style as the amount itself. **Deliberately low-key:** no badge, no color, no chip. The marker **clears automatically** once the user edits that ingredient, since the editor rebuilds it without the flag (touched = no longer an estimate).

## Touchpoints

- **Backend:** prompt schema (`estimated: boolean` per ingredient) + `RecipeDraft.DraftIngredient` + `ExtractionDraftResponse.DraftIngredientDto` + `ExtractionMapper`.
- **Frontend:** `IngredientDto` / `ExtractionDraftIngredient` types + `useExtractionReview` mapping + `RecipeIngredientRow` rendering (via the shared `RecipeEditorRenderers`).
- The flag is **stripped before accept**, so saved recipes and the accept contract are unchanged. Backward compatible (additive optional field, defaults false).

## Cost

Negligible — one extra boolean in the same single extraction call. No extra request, tokens, or latency.

## Verification

- Backend: compiles, `spotless:check` clean, `LlmRecipeExtractorTest` green.
- Frontend: `tsc --noEmit` unchanged from baseline, `eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)