### PR TITLE
chore(release): bump app version to 1.0.4

### DIFF
--- a/apps/expo-app/app.json
+++ b/apps/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "MealFlow",
     "slug": "mealflow",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "portrait",
     "icon": "./assets/icons/mealflow_icon_1024.png",
     "scheme": "mealflow",


### PR DESCRIPTION
## Summary

Bumps `expo.version` from 1.0.3 → **1.0.4** so the next iOS build can be submitted to TestFlight. The 1.0.3 submission was rejected by Apple because that `CFBundleShortVersionString` had already been submitted (EAS auto-increments the iOS `buildNumber`, but Apple keys the version on `expo.version`).

This build carries everything merged today:
- i18n EN/SV migration + in-app language switcher
- extraction: estimate missing ingredient amounts, translate to the chosen app language, and subtly flag estimated amounts in review

Frontend-only change (`app.json`). EAS handles the build number remotely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)