### PR TITLE
i18n: second sweep — interpolated & fallback strings (EN/SV)

### DIFF
--- a/apps/expo-app/src/features/auth/hooks/useVerifyEmail.ts
+++ b/apps/expo-app/src/features/auth/hooks/useVerifyEmail.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { authApi } from '@/src/features/auth/api/authApi';
 import { tokenStore } from '@/src/core/auth/tokenStore';
 import { authEvents } from '@/src/core/auth/authEvents';
@@ -34,6 +35,7 @@ export type VerifyEmailView = {
 const DEFAULT_RESEND_COOLDOWN_SECONDS = 60;
 
 export function useVerifyEmail(email: string): VerifyEmailView {
+  const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isResending, setIsResending] = useState(false);
   const [error, setError] = useState<UiError | null>(null);
@@ -69,8 +71,7 @@ export function useVerifyEmail(email: string): VerifyEmailView {
         if (apiErr.kind === 'http' && apiErr.code === 'INVALID_VERIFICATION_CODE') {
           setError({
             kind: 'validation',
-            message:
-              apiErr.detail || 'That code didn’t work. Double-check it or request a new one.',
+            message: apiErr.detail || t('auth.invalidCode'),
             status: apiErr.status,
           });
           return false;
@@ -85,7 +86,7 @@ export function useVerifyEmail(email: string): VerifyEmailView {
         setIsSubmitting(false);
       }
     },
-    [email, showError],
+    [email, showError, t],
   );
 
   const resend = useCallback(async (): Promise<boolean> => {
@@ -102,7 +103,7 @@ export function useVerifyEmail(email: string): VerifyEmailView {
         setResendCooldown(wait);
         setError({
           kind: 'rate_limit',
-          message: `Please wait ${wait} seconds before requesting a new code.`,
+          message: t('auth.resendWait', { seconds: wait }),
           status: apiErr.status,
           retryAfterSeconds: wait,
         });
@@ -115,7 +116,7 @@ export function useVerifyEmail(email: string): VerifyEmailView {
     } finally {
       setIsResending(false);
     }
-  }, [email, showError]);
+  }, [email, showError, t]);
 
   const state = useMemo<VerifyEmailState>(
     () => ({ isSubmitting, isResending, resendCooldown, error }),

--- a/apps/expo-app/src/features/profile/hooks/useProfileScreen.tsx
+++ b/apps/expo-app/src/features/profile/hooks/useProfileScreen.tsx
@@ -178,7 +178,7 @@ export function useProfileScreen(): ProfileScreenView {
   }, []);
 
   const data = useMemo<ProfileScreenData>(() => {
-    const displayName = profile?.displayName?.trim() || 'Your profile';
+    const displayName = profile?.displayName?.trim() || t('profile.yourProfile');
     const createdAt = profile?.createdAt ? new Date(profile.createdAt) : null;
     const memberSince = createdAt
       ? createdAt.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
@@ -192,7 +192,7 @@ export function useProfileScreen(): ProfileScreenView {
       planCount,
       listCount,
     };
-  }, [listCount, planCount, profile, recipeCount]);
+  }, [listCount, planCount, profile, recipeCount, t]);
 
   const state = useMemo<ProfileScreenState>(
     () => ({ isLoading, isRefreshing, error }),

--- a/apps/expo-app/src/features/recipes/hooks/useExtractionReview.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useExtractionReview.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { extractionApi } from '@/src/features/recipes/api/extractionApi';
 import type { ExtractionJob, IngredientDto } from '@/src/features/recipes/types';
 import { toApiError } from '@/src/core/http/toApiError';
@@ -27,6 +28,7 @@ export type ExtractionReviewView = {
 };
 
 export function useExtractionReview(jobId: string | undefined): ExtractionReviewView {
+  const { t } = useTranslation();
   const form = useRecipeFormState();
   const [ingredients, setIngredients] = useState<IngredientDto[]>([]);
   const [steps, setSteps] = useState<string[]>([]);
@@ -40,7 +42,7 @@ export function useExtractionReview(jobId: string | undefined): ExtractionReview
   const load = useCallback(async () => {
     if (!jobId) {
       setIsLoading(false);
-      setLoadError('Missing extraction id.');
+      setLoadError(t('recipes.missingExtractionId'));
       return;
     }
     setIsLoading(true);
@@ -51,14 +53,14 @@ export function useExtractionReview(jobId: string | undefined): ExtractionReview
       if (fresh.status !== 'READY') {
         setLoadError(
           fresh.status === 'FAILED'
-            ? fresh.errorMessage || 'Extraction failed.'
-            : 'Extraction is not ready yet.',
+            ? fresh.errorMessage || t('recipes.extractionFailed')
+            : t('recipes.extractionNotReady'),
         );
         return;
       }
       const draft = fresh.draft;
       if (!draft) {
-        setLoadError('Extraction has no draft.');
+        setLoadError(t('recipes.extractionNoDraft'));
         return;
       }
       form.setValues(
@@ -97,7 +99,7 @@ export function useExtractionReview(jobId: string | undefined): ExtractionReview
     // We intentionally only depend on jobId to avoid reloading on every form
     // change; form.setValues is stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobId]);
+  }, [jobId, t]);
 
   useEffect(() => {
     load();

--- a/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
@@ -76,7 +76,7 @@ export function useRecipeExtraction(): {
         if (isTerminal(next.status)) {
           setPhase(next.status === 'READY' ? 'ready' : 'failed');
           if (next.status === 'FAILED') {
-            setError(next.errorMessage || 'Extraction failed. Try a different file.');
+            setError(next.errorMessage || t('recipes.extractionFailedTryDifferent'));
           }
           return;
         }
@@ -91,10 +91,10 @@ export function useRecipeExtraction(): {
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
     if (!cancelledRef.current) {
-      setError('Extraction is taking too long. Please try again.');
+      setError(t('recipes.extractionTakingTooLong'));
       setPhase('failed');
     }
-  }, []);
+  }, [t]);
 
   const startUpload = useCallback(
     async (formData: FormData) => {

--- a/apps/expo-app/src/features/recipes/ui/RecipeDiscoveryListItem.tsx
+++ b/apps/expo-app/src/features/recipes/ui/RecipeDiscoveryListItem.tsx
@@ -30,7 +30,7 @@ export function RecipeDiscoveryListItem({
   return (
     <RecipeListCard
       title={item.title}
-      subtitle={subtitle || 'Discover recipe'}
+      subtitle={subtitle || t('overview.discoverRecipe')}
       imageUrl={item.imageUrl ?? undefined}
       onPress={() => onPress?.(item.id)}
       metaLeft={null}

--- a/apps/expo-app/src/features/weekly-plans/hooks/useWeeklyPlanDetailsScreen.tsx
+++ b/apps/expo-app/src/features/weekly-plans/hooks/useWeeklyPlanDetailsScreen.tsx
@@ -626,19 +626,19 @@ export function useWeeklyPlanDetailsScreen(): WeeklyPlanDetailsView {
 
   const clearWeekDescription = useMemo(() => {
     if (!plan) {
-      return 'This will remove all meals and reset sections to Breakfast, Lunch, and Dinner.';
+      return t('weeklyPlans.clearWeekBody');
     }
     const label = formatWeekRange(plan.weeklyStart);
-    return `This will remove all meals from ${label} and reset sections to Breakfast, Lunch, and Dinner.`;
-  }, [plan]);
+    return t('weeklyPlans.clearWeekBodyWithLabel', { label });
+  }, [plan, t]);
 
   const generateDescription = useMemo(() => {
     if (!plan) {
-      return 'This will replace your active shopping list with items from this week.';
+      return t('weeklyPlans.generateListBody');
     }
     const label = formatWeekRange(plan.weeklyStart);
-    return `This will replace your active shopping list with items from ${label}.`;
-  }, [plan]);
+    return t('weeklyPlans.generateListBodyWithLabel', { label });
+  }, [plan, t]);
 
   const resetAddForm = useCallback(() => {
     setSelectedRecipeId(null);

--- a/apps/expo-app/src/shared/i18n/locales/en.ts
+++ b/apps/expo-app/src/shared/i18n/locales/en.ts
@@ -14,6 +14,7 @@ export const en = {
     close: 'Close',
     confirm: 'Confirm',
     apply: 'Apply',
+    tryAgainInSeconds: 'Try again in {{seconds}}s',
     yes: 'Yes',
     no: 'No',
     or: 'or',
@@ -81,6 +82,8 @@ export const en = {
     verifyEmailBody: 'Enter the 6-digit code we just sent.',
     alreadyVerified: 'Already verified?',
     a11yVerificationCode: 'Verification code',
+    invalidCode: "That code didn't work. Double-check it or request a new one.",
+    resendWait: 'Please wait {{seconds}} seconds before requesting a new code.',
   },
 
   overview: {
@@ -323,6 +326,12 @@ export const en = {
     a11yReorderIngredient: 'Reorder ingredient',
     a11yReorderStep: 'Reorder step',
     a11yAddRecipe: 'Add recipe',
+    extractionFailed: 'Extraction failed.',
+    extractionFailedTryDifferent: 'Extraction failed. Try a different file.',
+    extractionTakingTooLong: 'Extraction is taking too long. Please try again.',
+    missingExtractionId: 'Missing extraction id.',
+    extractionNotReady: 'Extraction is not ready yet.',
+    extractionNoDraft: 'Extraction has no draft.',
 
     addRecipeSheet: {
       title: 'Add a recipe',
@@ -440,6 +449,12 @@ export const en = {
     weeklyPlan: 'Weekly Plan',
     viewWeekDetails: 'View Week Details',
     viewRecipe: 'View Recipe',
+    clearWeekBody: 'This will remove all meals and reset sections to Breakfast, Lunch, and Dinner.',
+    clearWeekBodyWithLabel:
+      'This will remove all meals from {{label}} and reset sections to Breakfast, Lunch, and Dinner.',
+    generateListBody: 'This will replace your active shopping list with items from this week.',
+    generateListBodyWithLabel:
+      'This will replace your active shopping list with items from {{label}}.',
 
     days: {
       monday: 'Monday',

--- a/apps/expo-app/src/shared/i18n/locales/sv.ts
+++ b/apps/expo-app/src/shared/i18n/locales/sv.ts
@@ -16,6 +16,7 @@ export const sv: Translations = {
     close: 'Stäng',
     confirm: 'Bekräfta',
     apply: 'Använd',
+    tryAgainInSeconds: 'Försök igen om {{seconds}}s',
     yes: 'Ja',
     no: 'Nej',
     or: 'eller',
@@ -83,6 +84,8 @@ export const sv: Translations = {
     verifyEmailBody: 'Ange den 6-siffriga koden vi precis skickade.',
     alreadyVerified: 'Redan verifierad?',
     a11yVerificationCode: 'Verifieringskod',
+    invalidCode: 'Koden fungerade inte. Dubbelkolla den eller begär en ny.',
+    resendWait: 'Vänta {{seconds}} sekunder innan du begär en ny kod.',
   },
 
   overview: {
@@ -326,6 +329,12 @@ export const sv: Translations = {
     a11yReorderIngredient: 'Ändra ordning på ingrediens',
     a11yReorderStep: 'Ändra ordning på steg',
     a11yAddRecipe: 'Lägg till recept',
+    extractionFailed: 'Extraheringen misslyckades.',
+    extractionFailedTryDifferent: 'Extraheringen misslyckades. Prova en annan fil.',
+    extractionTakingTooLong: 'Extraheringen tar för lång tid. Försök igen.',
+    missingExtractionId: 'Extraherings-id saknas.',
+    extractionNotReady: 'Extraheringen är inte klar än.',
+    extractionNoDraft: 'Extraheringen har inget utkast.',
 
     addRecipeSheet: {
       title: 'Lägg till recept',
@@ -443,6 +452,12 @@ export const sv: Translations = {
     weeklyPlan: 'Veckoplan',
     viewWeekDetails: 'Visa veckodetaljer',
     viewRecipe: 'Visa recept',
+    clearWeekBody: 'Detta tar bort alla måltider och återställer avsnitten till Frukost, Lunch och Middag.',
+    clearWeekBodyWithLabel:
+      'Detta tar bort alla måltider från {{label}} och återställer avsnitten till Frukost, Lunch och Middag.',
+    generateListBody: 'Detta ersätter din aktiva inköpslista med varor från den här veckan.',
+    generateListBodyWithLabel:
+      'Detta ersätter din aktiva inköpslista med varor från {{label}}.',
 
     days: {
       monday: 'Måndag',

--- a/apps/expo-app/src/shared/ui/FilterSheet/FilterSheet.tsx
+++ b/apps/expo-app/src/shared/ui/FilterSheet/FilterSheet.tsx
@@ -313,7 +313,7 @@ export function FilterSheet({
                     }}
                     value={tagInputs[section.key] ?? ''}
                     onChangeText={(text) => handleTagChange(section, text)}
-                    placeholder={section.placeholder ?? 'Add ingredient'}
+                    placeholder={section.placeholder ?? t('recipes.addIngredient')}
                     onAdd={() => handleAddTag(section)}
                     onFocus={() => {
                       setFocusedTagSectionKey(section.key);

--- a/apps/expo-app/src/shared/ui/GlobalToast/GlobalToastHost.tsx
+++ b/apps/expo-app/src/shared/ui/GlobalToast/GlobalToastHost.tsx
@@ -1,5 +1,6 @@
 import { Animated, PanResponder, StyleSheet, View } from 'react-native';
 import { useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ToastBanner } from '@/src/shared/ui/ToastBanner/ToastBanner';
 import { useRetryCountdown } from '@/src/shared/hooks/useRetryCountdown';
@@ -7,6 +8,7 @@ import { useGlobalToast } from './GlobalToastProvider';
 import { type Theme, useThemedStyles } from '@/src/shared/theme';
 
 export function GlobalToastHost() {
+  const { t } = useTranslation();
   const styles = useThemedStyles(createStyles);
   const { toast, clear } = useGlobalToast();
   const insets = useSafeAreaInsets();
@@ -59,9 +61,9 @@ export function GlobalToastHost() {
           variant={toast.variant}
           title={toast.title}
           message={toast.message}
-          meta={retry.remaining ? `Try again in ${retry.remaining}s` : toast.meta}
+          meta={retry.remaining ? t('common.tryAgainInSeconds', { seconds: retry.remaining }) : toast.meta}
           durationMs={toast.durationMs ?? 0}
-          actionLabel={toast.onAction ? (toast.actionLabel ?? 'Retry') : undefined}
+          actionLabel={toast.onAction ? (toast.actionLabel ?? t('common.retry')) : undefined}
           actionDisabled={retry.disabled || toast.actionDisabled}
           onAction={
             toast.onAction


### PR DESCRIPTION
## Summary

Per request, a deeper double-check before the next build. A broader scan (template literals, `??`/`||` fallbacks, `setError`/`message:` literals) surfaced strings the first sweep's patterns missed.

**Now translated:**
- **Interpolated copy** (new `{{label}}`/`{{seconds}}` keys): clear-week & generate-list confirm bodies, resend-cooldown wait message, and the global toast retry countdown ("Try again in {{seconds}}s") + "Retry" label.
- **Fallback strings:** verify-email invalid-code message, "Your profile", "Discover recipe", "Add ingredient", and the extraction load/poll errors (failed / taking too long / not ready yet / no draft / missing id).

## Verification
- Keys added to **both** `en.ts` and `sv.ts`; `tsc --noEmit` back to the pre-existing baseline (caught and fixed one wrong-namespace key — `discoverRecipe` lives under `overview`).
- `eslint` clean (added `t` to the relevant hook/memo dep arrays).
- Re-ran the full pattern battery (JSX text, props, alerts, templates, fallbacks, `message:`/`setError`) — **all clean**, except the intentionally-kept theme names and cuisine/category filter labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)