### PR TITLE
fix: Legal screen crash + Overview transparent backgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ target
 services/identity-service/.secrets/
 services/identity-service/*.pem
 services/identity-service/**/*.pem
+
+# Production deploy secrets (Hetzner)
+infra/.env.prod
+infra/secrets/
+infra/**/*.pem

--- a/apps/expo-app/src/features/overview/screens/OverviewScreen.tsx
+++ b/apps/expo-app/src/features/overview/screens/OverviewScreen.tsx
@@ -423,7 +423,7 @@ const createStyles = (theme: Theme) =>
     },
     carouselImageFallback: {
       flex: 1,
-      backgroundColor: theme.colors.surfaceAlt,
+      backgroundColor: theme.colors.surface,
     },
     carouselFade: {
       ...StyleSheet.absoluteFillObject,
@@ -496,7 +496,7 @@ const createStyles = (theme: Theme) =>
       width: 34,
       height: 34,
       borderRadius: 17,
-      backgroundColor: theme.colors.surfaceAlt,
+      backgroundColor: theme.colors.surface,
       alignItems: 'center',
       justifyContent: 'center',
     },
@@ -518,7 +518,7 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.textMuted,
     },
     weekBadge: {
-      backgroundColor: theme.colors.surfaceAlt,
+      backgroundColor: theme.colors.surface,
       borderRadius: 12,
       paddingHorizontal: 10,
       paddingVertical: 6,

--- a/apps/expo-app/src/features/settings/screens/LegalScreen.tsx
+++ b/apps/expo-app/src/features/settings/screens/LegalScreen.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import Constants from 'expo-constants';
@@ -5,7 +6,7 @@ import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { ChevronRight, FileText, Mail, ShieldCheck, Trash2 } from 'lucide-react-native';
 import { Card, Screen, useGlobalToast } from '@/src/shared/ui';
-import { type Theme, useThemedStyles } from '@/src/shared/theme';
+import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
 
 type LegalConfig = {
   privacyUrl?: string;
@@ -154,10 +155,12 @@ function LegalRow({
   onPress,
 }: {
   label: string;
-  icon: JSX.Element;
+  icon: ReactNode;
   iconBg: string;
   onPress: () => void;
 }) {
+  const styles = useThemedStyles(createStyles);
+  const theme = useTheme();
   return (
     <Pressable onPress={onPress}>
       <View style={styles.row}>

--- a/docs/dev/hetzner-deploy.md
+++ b/docs/dev/hetzner-deploy.md
@@ -1,0 +1,150 @@
+# Hetzner Deployment Runbook – MealFlow
+
+Move the two backend services off Render onto a single Hetzner VPS, behind
+Caddy (auto-TLS), with MongoDB staying on Atlas. The published mobile app is
+hardcoded to the `*.onrender.com` URLs, so this migration requires a **custom
+domain + a new app release**, and Render must keep running until old installs
+age out. See §7 for the cutover.
+
+Files this runbook uses (all in `infra/`):
+- `docker-compose.prod.yml` — the two services + Caddy
+- `Caddyfile` — reverse proxy for `api.<domain>` and `identity.<domain>`
+- `.env.prod.example` — template for all secrets/config
+
+---
+
+## 1. Provision the server
+
+- Hetzner Cloud → create a **CX22** (2 vCPU / 4 GB / 40 GB, ~€4.50/mo). 4 GB
+  comfortably runs both JVMs + Caddy. If on-box image builds are slow, resize to
+  CX32 (8 GB) temporarily, or build via CI and push images.
+- OS: Ubuntu 24.04.
+- Add your SSH key during creation.
+
+```sh
+ssh root@<SERVER_IP>
+
+# Docker Engine + compose plugin
+curl -fsSL https://get.docker.com | sh
+
+# Firewall: SSH + HTTP + HTTPS only (Atlas is reached outbound, no inbound rule needed)
+ufw allow OpenSSH && ufw allow 80 && ufw allow 443 && ufw --force enable
+```
+
+## 2. Get the code onto the box
+
+```sh
+# HTTPS clone for a public repo; for a private repo add a read-only deploy key first.
+git clone https://github.com/AlexCode-dot/mealflow.git /opt/mealflow
+cd /opt/mealflow/infra
+```
+
+## 3. DNS
+
+Point two A-records at the server (do this early — Let's Encrypt validates over
+HTTP, so DNS must resolve before step 6):
+
+| Record | Type | Value |
+|---|---|---|
+| `api.<domain>` | A | `<SERVER_IP>` |
+| `identity.<domain>` | A | `<SERVER_IP>` |
+
+## 4. Atlas network access
+
+Atlas → **Network Access** → add the server's public IP (`<SERVER_IP>/32`).
+Grab the two connection strings (identity-db and app-db) for the next step.
+
+## 5. JWT signing keys  ⚠️ read this carefully
+
+The identity service signs access tokens with an RSA key pair. **Reuse the keys
+that are already in production** — if you generate new ones, every currently
+valid access token fails verification until the client refreshes (a ≤15-min blip
+since refresh tokens are server-side and unaffected, but avoidable).
+
+```sh
+mkdir -p /opt/mealflow/infra/secrets/identity
+```
+
+- **Preferred:** copy the existing `private.pem` + `public.pem` from your Render
+  secret files (or wherever the current prod keys live) into
+  `infra/secrets/identity/`.
+- **Only if you have no existing keys** (fresh start — logs current users out):
+
+  ```sh
+  cd /opt/mealflow/infra/secrets/identity
+  openssl genpkey -algorithm RSA -pkcs8 -out private.pem -pkeyopt rsa_keygen_bits:2048
+  openssl pkey -in private.pem -pubout -out public.pem
+  cd /opt/mealflow/infra
+  ```
+
+The compose file mounts this directory read-only at `/app/.secrets`.
+
+## 6. Configure and launch
+
+```sh
+cp .env.prod.example .env.prod
+nano .env.prod          # fill in DOMAIN, Atlas URIs, Resend, ImageKit, Anthropic, WEB_ORIGIN
+
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+```
+
+First build pulls Temurin + builds both Spring Boot jars — a few minutes. Watch:
+
+```sh
+docker compose -f docker-compose.prod.yml logs -f
+```
+
+## 7. Verify
+
+```sh
+curl https://identity.<domain>/healthz
+curl https://app-api.<domain>/actuator/health   # → {"status":"UP"}  (path: api.<domain>/actuator/health)
+```
+
+Both should return TLS-valid responses (Caddy issued certs automatically). If a
+cert fails, re-check the A-records resolve and ports 80/443 are open.
+
+## 8. Cutover (the part that needs a new app release)
+
+Because the live app is compiled against `*.onrender.com`, you can't just flip
+DNS. Do this:
+
+1. Update `apps/expo-app/.env.production.local` **and** the EAS *production*
+   environment variables (eas.json uses `environment: production`, which pulls
+   from EAS cloud — the local file alone won't change the cloud build):
+   ```env
+   EXPO_PUBLIC_IDENTITY_BASE_URL=https://identity.<domain>
+   EXPO_PUBLIC_APP_API_BASE_URL=https://api.<domain>
+   ```
+2. Build + submit a new app version:
+   ```sh
+   cd apps/expo-app
+   eas build --profile production --platform all
+   eas submit --profile production --platform all
+   ```
+3. **Keep Render running.** Every already-installed app still calls
+   onrender.com. Retire Render only once that traffic is negligible (watch
+   Render's request metrics). Consider a minimum-supported-version gate in the
+   app to speed adoption.
+4. When Render traffic ~ zero → delete the two Render services. Savings start
+   here.
+
+## 9. Day-2 operations
+
+```sh
+# Redeploy (git pull + rebuild + restart in one step)
+/opt/mealflow/infra/deploy.sh
+
+# Logs / status / restart
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs -f app-api
+docker compose -f docker-compose.prod.yml restart app-api
+```
+
+Notes:
+- **Backups:** Atlas handles DB backups. The only state on the VPS is the JWT
+  keys in `infra/secrets/` — back that directory up off-box.
+- **TLS:** Caddy auto-renews; nothing to do.
+- **Single point of failure:** one box. Acceptable at this scale; if you outgrow
+  it, the path forward is a second box + load balancer, or back to a PaaS — and
+  since the app now uses your own domain, that future move is just DNS.

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -1,0 +1,41 @@
+# MealFlow production environment — copy to .env.prod on the server and fill in.
+#   cp .env.prod.example .env.prod && nano .env.prod
+# NEVER commit .env.prod. It is gitignored.
+
+# ── Domain ──────────────────────────────────────────────────────────────────
+# Subdomains api.<DOMAIN> and identity.<DOMAIN> must have A-records → this VPS.
+DOMAIN=example.com
+# Email used by Let's Encrypt for cert expiry notices.
+ACME_EMAIL=you@example.com
+# Origin allowed by CORS — your Expo Web app. Leave as the web URL, or set to the
+# domain if there is no separate web origin. Comma-separated for multiple.
+WEB_ORIGIN=https://app.example.com
+
+# ── MongoDB Atlas ───────────────────────────────────────────────────────────
+# Two logical databases in the same Atlas cluster. Whitelist this VPS's IP in
+# Atlas → Network Access first.
+IDENTITY_DB_URI=mongodb+srv://USER:PASS@cluster.xxxxx.mongodb.net/identity-db?retryWrites=true&w=majority
+APP_DB_URI=mongodb+srv://USER:PASS@cluster.xxxxx.mongodb.net/app-db?retryWrites=true&w=majority
+
+# ── JWT ─────────────────────────────────────────────────────────────────────
+# The RSA signing keys themselves are files in ./secrets/identity/ (private.pem,
+# public.pem) — see the runbook. These just tune token lifetimes (defaults shown).
+JWT_ACCESS_TTL_MIN=15
+JWT_REFRESH_TTL_DAYS=30
+
+# ── Email (Resend) ──────────────────────────────────────────────────────────
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# ── ImageKit (recipe images) ────────────────────────────────────────────────
+IMAGEKIT_PRIVATE_KEY=private_xxxxxxxxxxxxxxxxxxxxxxxx
+IMAGEKIT_PUBLIC_KEY=public_xxxxxxxxxxxxxxxxxxxxxxxx
+IMAGEKIT_URL_ENDPOINT=https://ik.imagekit.io/yourid
+IMAGEKIT_UPLOAD_FOLDER=/mealflow/recipes
+
+# ── Anthropic (recipe extraction) ───────────────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx
+# Cost lever: claude-haiku-4-5 is ~3x cheaper than claude-sonnet-4-6.
+# Test extraction quality on real recipes/videos before switching.
+ANTHROPIC_MODEL=claude-sonnet-4-6
+# Cost lever: fewer video frames = fewer image tokens. 5 is usually enough.
+APP_EXTRACTION_MAX_FRAMES=8

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,0 +1,18 @@
+# MealFlow reverse proxy. Caddy provisions and renews TLS certificates
+# automatically via Let's Encrypt for the two subdomains below.
+#
+# DOMAIN and ACME_EMAIL are injected from the environment (see docker-compose.prod.yml).
+
+{
+	email {$ACME_EMAIL}
+}
+
+# Identity Service — auth, JWKS, account management
+identity.{$DOMAIN} {
+	reverse_proxy identity-service:8081
+}
+
+# App API — recipes, weekly plans, shopping lists, extraction, inspiration
+api.{$DOMAIN} {
+	reverse_proxy app-api:8082
+}

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# MealFlow — one-command redeploy on the Hetzner VPS.
+#
+# Pulls latest main, rebuilds the changed service images, and restarts the stack
+# with zero config drift. Run from anywhere on the server:
+#   /opt/mealflow/infra/deploy.sh
+set -euo pipefail
+
+REPO_DIR="${MEALFLOW_REPO_DIR:-/opt/mealflow}"
+COMPOSE_FILE="docker-compose.prod.yml"
+ENV_FILE=".env.prod"
+
+cd "$REPO_DIR/infra"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: $REPO_DIR/infra/$ENV_FILE not found. Copy .env.prod.example and fill it in." >&2
+  exit 1
+fi
+
+echo "==> Pulling latest main"
+git -C "$REPO_DIR" pull --ff-only
+
+echo "==> Building and restarting"
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --build
+
+echo "==> Pruning dangling images"
+docker image prune -f >/dev/null
+
+echo "==> Status"
+docker compose -f "$COMPOSE_FILE" ps
+
+echo "==> Done. Tail logs with:"
+echo "    docker compose -f $REPO_DIR/infra/$COMPOSE_FILE logs -f"

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,107 @@
+# MealFlow — production stack for a single Hetzner VPS.
+#
+# Runs both Spring Boot services behind Caddy (auto-TLS). MongoDB is NOT here —
+# it stays managed on Atlas; inject the connection strings via .env.prod.
+#
+# Usage (from this infra/ directory):
+#   docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
+#
+# All ${VAR} below are substituted from --env-file .env.prod at parse time.
+name: mealflow
+
+services:
+  identity-service:
+    build:
+      context: ../services/identity-service
+    restart: unless-stopped
+    expose:
+      - "8081"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod          # Dockerfile defaults to dev — MUST override here
+      SPRING_MONGODB_URI: ${IDENTITY_DB_URI}
+      JWT_ISSUER: https://identity.${DOMAIN}
+      JWT_ACCESS_TTL_MIN: ${JWT_ACCESS_TTL_MIN:-15}
+      JWT_REFRESH_TTL_DAYS: ${JWT_REFRESH_TTL_DAYS:-30}
+      JWT_PRIVATE_KEY_PATH: file:/app/.secrets/private.pem
+      JWT_PUBLIC_KEY_PATH: file:/app/.secrets/public.pem
+      CORS_ALLOWED_ORIGINS: ${WEB_ORIGIN}
+      RESEND_API_KEY: ${RESEND_API_KEY}
+      INTEGRATION_TOKEN_ENV_SEGMENT: live
+      JAVA_TOOL_OPTIONS: -XX:MaxRAMPercentage=70
+    volumes:
+      # JWT signing keys live on the host and persist across deploys.
+      # Re-generating these logs every user out — see the runbook.
+      - ./secrets/identity:/app/.secrets:ro
+    mem_limit: 1024m
+    networks:
+      - mealflow
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8081' 2>/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+
+  app-api:
+    build:
+      context: ../services/app-api
+    restart: unless-stopped
+    expose:
+      - "8082"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_MONGODB_URI: ${APP_DB_URI}
+      # Read-only connection to the identity DB, used to validate integration tokens.
+      IDENTITY_SHARED_MONGODB_URI: ${IDENTITY_DB_URI}
+      # JWKS is fetched over the internal compose network — no need to exit through Caddy.
+      IDENTITY_JWKS_URI: http://identity-service:8081/.well-known/jwks.json
+      # Issuer is a claim string check — must match identity-service's JWT_ISSUER exactly.
+      IDENTITY_JWT_ISSUER: https://identity.${DOMAIN}
+      CORS_ALLOWED_ORIGINS: ${WEB_ORIGIN}
+      IMAGEKIT_PRIVATE_KEY: ${IMAGEKIT_PRIVATE_KEY}
+      IMAGEKIT_PUBLIC_KEY: ${IMAGEKIT_PUBLIC_KEY}
+      IMAGEKIT_URL_ENDPOINT: ${IMAGEKIT_URL_ENDPOINT}
+      IMAGEKIT_UPLOAD_FOLDER: ${IMAGEKIT_UPLOAD_FOLDER:-/mealflow/recipes}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-claude-sonnet-4-6}
+      APP_EXTRACTION_MAX_FRAMES: ${APP_EXTRACTION_MAX_FRAMES:-8}
+      JAVA_TOOL_OPTIONS: -XX:MaxRAMPercentage=70
+    mem_limit: 1280m
+    networks:
+      - mealflow
+    depends_on:
+      identity-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8082' 2>/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+      ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - mealflow
+    depends_on:
+      - identity-service
+      - app-api
+
+networks:
+  mealflow:
+    driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

Two pre-existing bugs found in a pre-release audit (both present in the current TestFlight 1.0.4):

### 🔴 Legal screen crash
`LegalRow` is a top-level function that referenced `styles` and `theme` from `LegalScreen`'s inner scope — neither is in `LegalRow`'s scope, so rendering **Settings → Legal (Privacy Policy / Terms / Account deletion)** threw `ReferenceError: styles is not defined` and crashed the screen. Since App Store requires an accessible privacy policy, this matters for compliance.
Fix: `LegalRow` gets its own `useThemedStyles(createStyles)` + `useTheme()`, and `icon` is typed `ReactNode` (was the unresolved global `JSX.Element`).

### 🟠 Overview transparent backgrounds
Three styles referenced `theme.colors.surfaceAlt`, which doesn't exist on the theme → `backgroundColor: undefined` → the carousel image fallback, find-chevron wrap, and week badge rendered with no background. Fix: use the existing `surface` color.

## Verification
- `tsc --noEmit`: 41 → 33 errors (the 8 resolved are exactly these two bugs' cascades); no new errors.
- `eslint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)