### PR TITLE
feat(extraction): support multiple photos for one recipe import

### DIFF
--- a/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
@@ -12,6 +12,9 @@ const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 90 * 1000;
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 const MAX_VIDEO_BYTES = 100 * 1024 * 1024;
+// A recipe can span several photos (ingredients on one, steps on another). Keep this in
+// sync with the backend `app.extraction.max-image-count`.
+const MAX_IMAGES = 5;
 
 type Phase = 'idle' | 'uploading' | 'processing' | 'ready' | 'failed';
 
@@ -136,12 +139,28 @@ export function useRecipeExtraction(): {
     return formData;
   }, []);
 
-  const pickWebFile = useCallback((accept: string): Promise<File | null> => {
+  const buildImagesFormData = useCallback(
+    (images: { uri: string; name: string; type: string }[]): FormData => {
+      const formData = new FormData();
+      images.forEach((img) => {
+        formData.append('file', {
+          uri: img.uri,
+          name: img.name,
+          type: img.type,
+        } as unknown as Blob);
+      });
+      return formData;
+    },
+    [],
+  );
+
+  const pickWebFiles = useCallback((accept: string, multiple: boolean): Promise<File[]> => {
     return new Promise((resolve) => {
       const input = document.createElement('input');
       input.type = 'file';
       input.accept = accept;
-      input.onchange = () => resolve(input.files?.[0] ?? null);
+      input.multiple = multiple;
+      input.onchange = () => resolve(input.files ? Array.from(input.files) : []);
       input.click();
     });
   }, []);
@@ -149,23 +168,25 @@ export function useRecipeExtraction(): {
   const startFromWeb = useCallback(
     async (kind: 'image' | 'video') => {
       const accept = kind === 'image' ? 'image/*' : 'video/*';
-      const file = await pickWebFile(accept);
-      if (!file) return;
+      const picked = await pickWebFiles(accept, kind === 'image');
+      if (!picked.length) return;
+      const files = kind === 'image' ? picked.slice(0, MAX_IMAGES) : picked.slice(0, 1);
 
       const max = kind === 'image' ? MAX_IMAGE_BYTES : MAX_VIDEO_BYTES;
-      if (file.size > max) {
-        const message =
-          kind === 'image'
-            ? 'Image is too large. Please choose a smaller photo.'
-            : 'Video is too large (max 100 MB).';
-        showError({ kind: 'unknown', message });
+      if (files.some((f) => f.size > max)) {
+        showError({
+          kind: 'unknown',
+          message: kind === 'image' ? t('recipes.imageTooLarge') : t('recipes.videoTooLarge'),
+        });
         return;
       }
       const formData = new FormData();
-      formData.append('file', file, file.name || `recipe.${kind === 'image' ? 'jpg' : 'mp4'}`);
+      files.forEach((f, idx) => {
+        formData.append('file', f, f.name || `recipe-${idx}.${kind === 'image' ? 'jpg' : 'mp4'}`);
+      });
       await startUpload(formData);
     },
-    [pickWebFile, showError, startUpload],
+    [pickWebFiles, showError, startUpload, t],
   );
 
   const startFromImage = useCallback(async () => {
@@ -188,21 +209,23 @@ export function useRecipeExtraction(): {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes,
       quality: 0.9,
+      allowsMultipleSelection: true,
+      selectionLimit: MAX_IMAGES,
     });
     if (result.canceled || !result.assets?.length) return;
-    const asset = result.assets[0];
-    if (asset.fileSize && asset.fileSize > MAX_IMAGE_BYTES) {
-      showError({
-        kind: 'unknown',
-        message: t('recipes.imageTooLarge'),
-      });
+    const assets = result.assets.slice(0, MAX_IMAGES);
+    if (assets.some((a) => a.fileSize && a.fileSize > MAX_IMAGE_BYTES)) {
+      showError({ kind: 'unknown', message: t('recipes.imageTooLarge') });
       return;
     }
-    const fileName = asset.fileName ?? `recipe-${Date.now()}.jpg`;
-    const mime = asset.mimeType ?? 'image/jpeg';
-    const formData = buildFormData(asset.uri, fileName, mime);
+    const images = assets.map((a, idx) => ({
+      uri: a.uri,
+      name: a.fileName ?? `recipe-${Date.now()}-${idx}.jpg`,
+      type: a.mimeType ?? 'image/jpeg',
+    }));
+    const formData = buildImagesFormData(images);
     await startUpload(formData);
-  }, [buildFormData, showError, startFromWeb, startUpload, t]);
+  }, [buildImagesFormData, showError, startFromWeb, startUpload, t]);
 
   const startFromVideo = useCallback(async () => {
     if (Platform.OS === 'web') {

--- a/apps/expo-app/src/shared/i18n/locales/en.ts
+++ b/apps/expo-app/src/shared/i18n/locales/en.ts
@@ -337,7 +337,7 @@ export const en = {
       title: 'Add a recipe',
       writeItYourself: 'Write it yourself',
       fromAPhoto: 'From a photo',
-      fromAPhotoSubtitle: 'Screenshot of a recipe',
+      fromAPhotoSubtitle: 'One or more photos of a recipe',
       fromAVideo: 'From a video',
       fromAVideoSubtitle: 'TikTok, Reel or short clip',
     },

--- a/apps/expo-app/src/shared/i18n/locales/sv.ts
+++ b/apps/expo-app/src/shared/i18n/locales/sv.ts
@@ -340,7 +340,7 @@ export const sv: Translations = {
       title: 'Lägg till recept',
       writeItYourself: 'Skriv det själv',
       fromAPhoto: 'Från ett foto',
-      fromAPhotoSubtitle: 'Skärmbild av ett recept',
+      fromAPhotoSubtitle: 'Ett eller flera foton av ett recept',
       fromAVideo: 'Från en video',
       fromAVideoSubtitle: 'TikTok, Reel eller kort klipp',
     },

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/config/ExtractionProperties.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/config/ExtractionProperties.java
@@ -17,6 +17,9 @@ public class ExtractionProperties {
     @Min(1)
     private long maxVideoBytes = 100L * 1024 * 1024; // 100 MB
 
+    @Min(1)
+    private int maxImageCount = 5; // max images per image-based extraction
+
     @Min(0)
     private int maxPerDay = 10;
 
@@ -56,6 +59,14 @@ public class ExtractionProperties {
 
     public void setMaxVideoBytes(long maxVideoBytes) {
         this.maxVideoBytes = maxVideoBytes;
+    }
+
+    public int getMaxImageCount() {
+        return maxImageCount;
+    }
+
+    public void setMaxImageCount(int maxImageCount) {
+        this.maxImageCount = maxImageCount;
     }
 
     public int getMaxPerDay() {

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
@@ -40,35 +40,39 @@ public class ExtractionJobProcessor {
         this.clock = clock;
     }
 
-    public void process(String jobId, Path mediaPath, String languageName, String unitSystem) {
+    public void process(String jobId, List<StoredMedia> media, String languageName, String unitSystem) {
         ExtractionJob job = jobRepository.findById(jobId).orElse(null);
         if (job == null) {
+            media.forEach(mediaIngest::cleanup);
             return;
         }
 
         Path framesDir = null;
-        StoredMedia tempMedia =
-                new StoredMedia(mediaPath, job.getSourceType(), job.getContentType(), job.getSizeBytes());
+        StoredMedia primary = media.get(0);
 
         try {
             List<ExtractedFrame> frames;
             if (job.getSourceType() == ExtractionSourceType.IMAGE) {
-                frames = List.of(new ExtractedFrame(mediaPath, imageMediaType(job.getContentType())));
+                // One frame per uploaded image — a recipe can span several photos, and the LLM
+                // reads them together (in upload order) in a single request.
+                frames = media.stream()
+                        .map(m -> new ExtractedFrame(m.path(), imageMediaType(m.contentType())))
+                        .toList();
             } else {
                 framesDir = mediaIngest.workspaceFor(jobId + "_frames");
-                frames = frameExtractor.extract(mediaPath, framesDir);
+                frames = frameExtractor.extract(primary.path(), framesDir);
             }
 
             RecipeDraft draft = llmExtractor.extract(frames, languageName, unitSystem);
             job.setDraft(draft);
 
-            // For image sources we auto-upload the source image as a thumbnail (the user can
+            // For image sources we auto-upload the first image as a thumbnail (the user can
             // change it on the review screen if they want). For video sources we upload nothing
             // here — the client picks a frame on-device after extraction completes and uploads
             // only that one frame via the regular image-upload endpoint.
             if (job.getSourceType() == ExtractionSourceType.IMAGE) {
                 ImageKitUploadResult uploaded =
-                        thumbnailService.uploadThumbnail(job.getUserId(), jobId, job.getSourceType(), mediaPath);
+                        thumbnailService.uploadThumbnail(job.getUserId(), jobId, job.getSourceType(), primary.path());
                 if (uploaded != null) {
                     job.setThumbnailUrl(uploaded.url());
                     job.setThumbnailFileId(uploaded.fileId());
@@ -92,7 +96,7 @@ public class ExtractionJobProcessor {
             job.setUpdatedAt(clock.instant());
             jobRepository.save(job);
         } finally {
-            mediaIngest.cleanup(tempMedia);
+            media.forEach(mediaIngest::cleanup);
             if (framesDir != null) {
                 mediaIngest.cleanupDirectory(framesDir);
             }

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/MediaIngestService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/MediaIngestService.java
@@ -30,6 +30,10 @@ public class MediaIngestService {
     }
 
     public StoredMedia store(MultipartFile file, String jobId) {
+        return store(file, jobId, 0);
+    }
+
+    public StoredMedia store(MultipartFile file, String jobId, int index) {
         if (file == null || file.isEmpty()) {
             throw new ExtractionValidationException("Please choose a file to upload.");
         }
@@ -47,7 +51,8 @@ public class MediaIngestService {
         }
 
         try {
-            Path target = workspaceRoot.resolve(jobId + suffixFor(contentType));
+            // Index keeps multiple images for one job from overwriting each other on disk.
+            Path target = workspaceRoot.resolve(jobId + "-" + index + suffixFor(contentType));
             try (InputStream in = file.getInputStream()) {
                 Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
             }

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
@@ -3,12 +3,12 @@ package com.mealflow.appapi.recipes.extraction.service;
 import com.mealflow.appapi.recipes.domain.Ingredient;
 import com.mealflow.appapi.recipes.domain.Recipe;
 import com.mealflow.appapi.recipes.extraction.config.ExtractionAsyncConfig;
+import com.mealflow.appapi.recipes.extraction.config.ExtractionProperties;
 import com.mealflow.appapi.recipes.extraction.domain.ExtractionJob;
 import com.mealflow.appapi.recipes.extraction.domain.ExtractionSourceType;
 import com.mealflow.appapi.recipes.extraction.domain.ExtractionStatus;
 import com.mealflow.appapi.recipes.extraction.repository.ExtractionJobRepository;
 import com.mealflow.appapi.recipes.service.RecipeService;
-import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +27,7 @@ public class RecipeExtractionService {
     private final ExtractionJobProcessor jobProcessor;
     private final RecipeService recipeService;
     private final ExtractionThumbnailService thumbnailService;
+    private final ExtractionProperties properties;
     private final TaskExecutor extractionExecutor;
     private final Clock clock;
 
@@ -38,6 +39,7 @@ public class RecipeExtractionService {
             ExtractionJobProcessor jobProcessor,
             RecipeService recipeService,
             ExtractionThumbnailService thumbnailService,
+            ExtractionProperties properties,
             @Qualifier(ExtractionAsyncConfig.EXECUTOR_BEAN) TaskExecutor extractionExecutor,
             Clock clock) {
         this.jobRepository = jobRepository;
@@ -47,11 +49,15 @@ public class RecipeExtractionService {
         this.jobProcessor = jobProcessor;
         this.recipeService = recipeService;
         this.thumbnailService = thumbnailService;
+        this.properties = properties;
         this.extractionExecutor = extractionExecutor;
         this.clock = clock;
     }
 
-    public ExtractionJob enqueue(String userId, MultipartFile file, String locale) {
+    public ExtractionJob enqueue(String userId, List<MultipartFile> files, String locale) {
+        if (files == null || files.isEmpty()) {
+            throw new ExtractionValidationException("Please choose a file to upload.");
+        }
         quotaService.enforce(userId);
 
         ExtractionLocaleResolver.Resolved resolved = localeResolver.resolve(locale);
@@ -67,26 +73,42 @@ public class RecipeExtractionService {
                 clock.instant());
         job = jobRepository.save(job);
 
-        StoredMedia stored;
+        List<StoredMedia> stored = new ArrayList<>();
         try {
-            stored = mediaIngest.store(file, job.getId());
+            // Store the first file to learn whether this is an image or video upload.
+            stored.add(mediaIngest.store(files.get(0), job.getId(), 0));
+
+            // A recipe can span several photos (ingredients on one, steps on another). For image
+            // uploads we keep up to maxImageCount of them; video is always a single upload.
+            if (stored.get(0).sourceType() == ExtractionSourceType.IMAGE) {
+                int count = Math.min(files.size(), properties.getMaxImageCount());
+                for (int i = 1; i < count; i++) {
+                    MultipartFile f = files.get(i);
+                    if (f != null && !f.isEmpty()) {
+                        stored.add(mediaIngest.store(f, job.getId(), i));
+                    }
+                }
+            }
         } catch (RuntimeException ex) {
+            stored.forEach(mediaIngest::cleanup);
             jobRepository.deleteById(job.getId());
             throw ex;
         }
 
-        job.setSourceType(stored.sourceType());
-        job.setContentType(stored.contentType());
-        job.setSizeBytes(stored.sizeBytes());
+        StoredMedia primary = stored.get(0);
+        long totalBytes = stored.stream().mapToLong(StoredMedia::sizeBytes).sum();
+        job.setSourceType(primary.sourceType());
+        job.setContentType(primary.contentType());
+        job.setSizeBytes(totalBytes);
         job.setStatus(ExtractionStatus.PROCESSING);
         job.setUpdatedAt(clock.instant());
         jobRepository.save(job);
 
         String jobId = job.getId();
-        Path mediaPath = stored.path();
+        List<StoredMedia> media = List.copyOf(stored);
         String languageName = resolved.languageName();
         String unitSystem = resolved.unitSystem();
-        extractionExecutor.execute(() -> jobProcessor.process(jobId, mediaPath, languageName, unitSystem));
+        extractionExecutor.execute(() -> jobProcessor.process(jobId, media, languageName, unitSystem));
         return job;
     }
 

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
@@ -10,6 +10,7 @@ import com.mealflow.appapi.recipes.web.mapper.RecipeMapper;
 import com.mealflow.appapi.security.config.CurrentUser;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -46,11 +47,11 @@ public class ExtractionController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ExtractionJobResponse> create(
-            @RequestPart("file") MultipartFile file,
+            @RequestPart("file") List<MultipartFile> files,
             @RequestParam(value = "locale", required = false) String locale,
             Authentication auth) {
         String userId = currentUser.userId(auth);
-        ExtractionJob job = service.enqueue(userId, file, locale);
+        ExtractionJob job = service.enqueue(userId, files, locale);
         ExtractionJobResponse response = extractionMapper.toResponse(job);
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .location(URI.create("/api/recipes/extract/" + job.getId()))


### PR DESCRIPTION
## Summary

A recipe often doesn't fit in a single photo — ingredients on one page, steps on another. The LLM extractor already reasons over a **list** of frames (that's how video works: ffmpeg → many frames → one request). This wires the image path to carry **multiple photos** through the upload so "From a photo" can accept several at once.

## Backend
- `ExtractionController` accepts `List<MultipartFile>` for the `file` part (a single-file request still binds to a 1-element list — existing behavior unchanged).
- `enqueue()` stores up to `app.extraction.max-image-count` images (default **5**); `MediaIngestService` writes each to an **indexed path** so they don't overwrite each other.
- `ExtractionJobProcessor` builds **one frame per image**, in upload order, and sends them together in a **single** LLM request. First image becomes the auto-thumbnail. Video stays a single upload.

## Frontend (`useRecipeExtraction`)
- Image picker uses `allowsMultipleSelection` + `selectionLimit: 5`; all picked assets upload as separate `file` parts (native **and** web).
- "From a photo" subtitle now hints *"one or more photos"* (EN/SV).

## Cost
Negligible — a few extra input tokens per added image on the same single extraction call (same order of magnitude a video already costs). Capped at 5 images.

## Verification
- Backend: compiles, `spotless:check` clean, `ExtractionControllerIT` + `LlmRecipeExtractorTest` green.
- Frontend: `tsc --noEmit` unchanged from baseline (the 2 errors shown in the file are the pre-existing `MediaTypeOptions` deprecation), `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)