### PR TITLE
fix(auth): re-send verification code on unverified login

### DIFF
--- a/apps/expo-app/src/features/auth/hooks/useLogin.ts
+++ b/apps/expo-app/src/features/auth/hooks/useLogin.ts
@@ -48,6 +48,10 @@ export const useLogin = (): LoginView => {
       } catch (e) {
         const apiErr = toApiError(e);
         if (apiErr.kind === 'http' && apiErr.code === 'EMAIL_NOT_VERIFIED') {
+          // Login never issues a verification code, so proactively (re)send one — otherwise the
+          // user lands on the verify screen with no fresh code. Ignore failures (e.g. resend
+          // cooldown): the previously issued code is still usable in that case.
+          await authApi.resendVerification(email.trim()).catch(() => {});
           return { kind: 'verification-required', email: email.trim() };
         }
         const uiErr = mapAuthError(apiErr);


### PR DESCRIPTION
## Summary

Found while testing signup on live: logging in with an **unverified** account correctly bounces you to the verify-email screen, but **no code is sent** that time — the backend login path only throws `EMAIL_NOT_VERIFIED` (it never issues a code), and the frontend navigated to verify without triggering a resend. Worse, the verify screen shows a 60s resend cooldown as if a code had just been sent, so the user waits for nothing.

Fix: `useLogin` now calls `resendVerification(email)` when login returns `EMAIL_NOT_VERIFIED`, before navigating. Failures (e.g. hitting the resend cooldown because a code really was sent moments ago) are ignored — the previously issued code is still valid then.

Frontend-only; uses the existing `/auth/resend-verification` endpoint.

## Verification
- `tsc --noEmit` unchanged from baseline; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)