### PR TITLE
feat(profile): show the account email (GET /auth/me)

### DIFF
--- a/apps/expo-app/src/core/http/httpClient.ts
+++ b/apps/expo-app/src/core/http/httpClient.ts
@@ -11,30 +11,32 @@ import { parseResponseBody, request } from './request';
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 async function authedRequest<T>(
+  baseUrl: string,
   path: string,
   method: HttpMethod,
   options?: { body?: unknown; accessTokenOverride?: string },
 ): Promise<T> {
   const token = options?.accessTokenOverride ?? tokenStore.getAccessToken();
 
-  return request<T>(ENV.APP_API_BASE_URL, path, method, {
+  return request<T>(baseUrl, path, method, {
     body: options?.body,
     headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
 }
 
 async function requestWithAutoRefresh<T>(
+  baseUrl: string,
   path: string,
   method: HttpMethod,
   options?: { body?: unknown },
 ): Promise<T> {
   try {
-    return await authedRequest<T>(path, method, { body: options?.body });
+    return await authedRequest<T>(baseUrl, path, method, { body: options?.body });
   } catch (err) {
     if (err instanceof HttpError && err.status === 401) {
       try {
         const newAccess = await refreshSession();
-        return await authedRequest<T>(path, method, {
+        return await authedRequest<T>(baseUrl, path, method, {
           body: options?.body,
           accessTokenOverride: newAccess,
         });
@@ -110,14 +112,20 @@ export const httpClient = {
   identity: {
     post: <T>(path: string, body: unknown) =>
       request<T>(ENV.IDENTITY_BASE_URL, path, 'POST', { body }),
+    // Authenticated GET against identity (e.g. /auth/me) — attaches the access token and
+    // retries once after a refresh on 401, same as app-api calls.
+    get: <T>(path: string) => requestWithAutoRefresh<T>(ENV.IDENTITY_BASE_URL, path, 'GET'),
   },
 
   appApi: {
-    get: <T>(path: string) => requestWithAutoRefresh<T>(path, 'GET'),
-    post: <T>(path: string, body: unknown) => requestWithAutoRefresh<T>(path, 'POST', { body }),
-    put: <T>(path: string, body: unknown) => requestWithAutoRefresh<T>(path, 'PUT', { body }),
-    patch: <T>(path: string, body: unknown) => requestWithAutoRefresh<T>(path, 'PATCH', { body }),
-    delete: <T>(path: string) => requestWithAutoRefresh<T>(path, 'DELETE'),
+    get: <T>(path: string) => requestWithAutoRefresh<T>(ENV.APP_API_BASE_URL, path, 'GET'),
+    post: <T>(path: string, body: unknown) =>
+      requestWithAutoRefresh<T>(ENV.APP_API_BASE_URL, path, 'POST', { body }),
+    put: <T>(path: string, body: unknown) =>
+      requestWithAutoRefresh<T>(ENV.APP_API_BASE_URL, path, 'PUT', { body }),
+    patch: <T>(path: string, body: unknown) =>
+      requestWithAutoRefresh<T>(ENV.APP_API_BASE_URL, path, 'PATCH', { body }),
+    delete: <T>(path: string) => requestWithAutoRefresh<T>(ENV.APP_API_BASE_URL, path, 'DELETE'),
     upload: <T>(path: string, formData: FormData) => multipartWithAutoRefresh<T>(path, formData),
   },
 };

--- a/apps/expo-app/src/features/auth/api/authApi.ts
+++ b/apps/expo-app/src/features/auth/api/authApi.ts
@@ -17,4 +17,8 @@ export const authApi = {
   resendVerification(email: string): Promise<void> {
     return httpClient.identity.post<void>('/auth/resend-verification', { email });
   },
+
+  me(): Promise<{ userId: string; email: string }> {
+    return httpClient.identity.get<{ userId: string; email: string }>('/auth/me');
+  },
 };

--- a/apps/expo-app/src/features/profile/hooks/useAccountEmail.ts
+++ b/apps/expo-app/src/features/profile/hooks/useAccountEmail.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { authApi } from '@/src/features/auth/api/authApi';
+
+/**
+ * Fetches the signed-in user's email from identity (`GET /auth/me`). The email lives in
+ * identity-service, not in the app-api profile, so it isn't part of the profile payload.
+ * Returns null until loaded (or on failure), so callers can fall back to a placeholder.
+ */
+export function useAccountEmail(): string | null {
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    authApi
+      .me()
+      .then((me) => {
+        if (active) setEmail(me.email);
+      })
+      .catch(() => {
+        // Leave null → caller shows its placeholder.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return email;
+}

--- a/apps/expo-app/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/apps/expo-app/src/features/profile/screens/ProfileEditScreen.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Check, ChevronRight, UserRound, XCircle } from 'lucide-react-native';
 import { useIsFocused } from '@react-navigation/native';
 import { useProfileEditScreen } from '@/src/features/profile/hooks/useProfileEditScreen';
+import { useAccountEmail } from '@/src/features/profile/hooks/useAccountEmail';
 import { ThemePickerSheet } from '@/src/features/settings/ui/ThemePickerSheet';
 import {
   Card,
@@ -25,6 +26,7 @@ export function ProfileEditScreen() {
   const theme = useTheme();
   const styles = useThemedStyles(createStyles);
   const view = useProfileEditScreen();
+  const accountEmail = useAccountEmail();
   const { state, form, data, actions, toast } = view;
   const [themeOpen, setThemeOpen] = useState(false);
   const isFocused = useIsFocused();
@@ -105,7 +107,7 @@ export function ProfileEditScreen() {
           <View style={styles.readOnlyBlock}>
             <Text style={styles.label}>{t('profile.emailLabel')}</Text>
             <View style={styles.readOnlyField}>
-              <Text style={styles.readOnlyText}>{t('profile.notAvailable')}</Text>
+              <Text style={styles.readOnlyText}>{accountEmail ?? t('profile.notAvailable')}</Text>
             </View>
           </View>
 

--- a/apps/expo-app/src/features/profile/screens/ProfileScreen.tsx
+++ b/apps/expo-app/src/features/profile/screens/ProfileScreen.tsx
@@ -17,6 +17,7 @@ import {
 import * as Clipboard from 'expo-clipboard';
 import Constants from 'expo-constants';
 import { useProfileScreen } from '@/src/features/profile/hooks/useProfileScreen';
+import { useAccountEmail } from '@/src/features/profile/hooks/useAccountEmail';
 import { Card, LoadingScreen, Screen, ToastBanner, useGlobalToast } from '@/src/shared/ui';
 import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
 
@@ -30,6 +31,7 @@ export function ProfileScreen({ showBack = false }: Props) {
   const styles = useThemedStyles(createStyles);
   const view = useProfileScreen();
   const { state, data, actions, toast } = view;
+  const accountEmail = useAccountEmail();
   const { toast: globalToast, showValidationError, show } = useGlobalToast();
   const legal = Constants.expoConfig?.extra?.legal as
     | { privacyUrl?: string; termsUrl?: string }
@@ -147,7 +149,7 @@ export function ProfileScreen({ showBack = false }: Props) {
           <View style={styles.infoDivider} />
           <InfoRow
             label={t('profile.emailLabel')}
-            value={t('profile.notAvailable')}
+            value={accountEmail ?? t('profile.notAvailable')}
             icon={<Mail size={20} color="#2463EB" strokeWidth={2.4} />}
             iconBg="#E6EEFF"
             styles={styles}

--- a/services/identity-service/src/main/java/com/mealflow/identity/auth/AuthService.java
+++ b/services/identity-service/src/main/java/com/mealflow/identity/auth/AuthService.java
@@ -94,6 +94,13 @@ public class AuthService {
         emailVerificationService.resendFor(normalizeEmail(email));
     }
 
+    public String getUserEmail(String userId) {
+        return userRepository
+                .findById(userId)
+                .map(User::getEmail)
+                .orElseThrow(() -> new InvalidCredentialsException("User not found"));
+    }
+
     public AuthTokens refresh(String refreshTokenRaw) {
         IssuedRefreshToken rotated = refreshTokenService.rotate(refreshTokenRaw);
         String accessToken = accessTokenService.issue(rotated.userId());

--- a/services/identity-service/src/main/java/com/mealflow/identity/security/config/SecurityConfig.java
+++ b/services/identity-service/src/main/java/com/mealflow/identity/security/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/auth/integrations", "/auth/integrations/**")
                         .authenticated()
+                        .requestMatchers(HttpMethod.GET, "/auth/me")
+                        .authenticated()
                         .requestMatchers("/auth/**", "/.well-known/jwks.json")
                         .permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/account")

--- a/services/identity-service/src/main/java/com/mealflow/identity/web/auth/AuthController.java
+++ b/services/identity-service/src/main/java/com/mealflow/identity/web/auth/AuthController.java
@@ -14,6 +14,8 @@ import jakarta.validation.Valid;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -132,6 +134,12 @@ public class AuthController {
                     Map.of("reason", "email_not_verified"));
             throw e;
         }
+    }
+
+    @GetMapping("/me")
+    public MeResponse me(@AuthenticationPrincipal Jwt jwt) {
+        String userId = jwt.getSubject();
+        return new MeResponse(userId, authService.getUserEmail(userId));
     }
 
     @PostMapping("/refresh")

--- a/services/identity-service/src/main/java/com/mealflow/identity/web/auth/dto/MeResponse.java
+++ b/services/identity-service/src/main/java/com/mealflow/identity/web/auth/dto/MeResponse.java
@@ -1,0 +1,4 @@
+package com.mealflow.identity.web.auth.dto;
+
+/** Current authenticated user, returned from GET /auth/me. */
+public record MeResponse(String userId, String email) {}

--- a/services/identity-service/src/test/java/com/mealflow/identity/web/auth/AuthControllerIT.java
+++ b/services/identity-service/src/test/java/com/mealflow/identity/web/auth/AuthControllerIT.java
@@ -156,9 +156,36 @@ class AuthControllerIT extends MongoTestContainerConfig {
         assertThat(response.statusCode(), is(202));
     }
 
+    @Test
+    void me_returnsEmail_whenAuthenticated_and401_whenNot() throws Exception {
+        String email = "me.test@mealflow.dev";
+        String password = "VeryStrongPass123!";
+        assertThat(post("/auth/register", jsonRegister(email, password)).statusCode(), is(201));
+        forceVerifyEmail(email);
+        Tokens tokens =
+                extractTokens(post("/auth/login", jsonLogin(email, password)).body());
+
+        HttpResponse<String> me = getWithBearer("/auth/me", tokens.accessToken());
+        assertThat(me.statusCode(), is(200));
+        assertThat(JsonPath.read(me.body(), "$.email").toString(), is(email));
+
+        HttpResponse<String> unauth = getWithBearer("/auth/me", null);
+        assertThat(unauth.statusCode(), is(401));
+    }
+
     // -------------------------
     // HTTP helpers
     // -------------------------
+
+    private HttpResponse<String> getWithBearer(String path, String token) throws Exception {
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + path))
+                .GET();
+        if (token != null) {
+            b.header(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        return http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+    }
 
     private HttpResponse<String> post(String path, String json) throws Exception {
         HttpRequest req = HttpRequest.newBuilder()


### PR DESCRIPTION
## Summary

The profile screens showed **"Not available"** for the account email because the app had no source for it: the app-api `/api/profile` payload has no email, and it isn't a JWT claim either. The email lives in **identity-service**.

- **Backend:** new authenticated `GET /auth/me` on identity returning `{ userId, email }` (SecurityConfig marks it `authenticated` before the `/auth/**` permitAll rule; `AuthService.getUserEmail` loads it). Added an `AuthControllerIT` test: 200 + correct email with a token, 401 without.
- **Frontend:** `httpClient.identity` gains an authed `get()` (attaches the access token, retries once after refresh on 401 — the auth helpers are now baseURL-parameterized). New `useAccountEmail` hook; the Profile (contact info) and Edit-Profile screens display the real email, falling back to the placeholder while loading or on error.

## Verification
- Backend: compiles, `spotless:check` clean, `AuthControllerIT` (incl. new `/auth/me` test) + `IdentityServiceApplicationTests` green.
- Frontend: `tsc --noEmit` back to baseline, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)