### PR TITLE
chore(release): bump app version to 1.0.5

### DIFF
--- a/apps/expo-app/app.json
+++ b/apps/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "MealFlow",
     "slug": "mealflow",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "orientation": "portrait",
     "icon": "./assets/icons/mealflow_icon_1024.png",
     "scheme": "mealflow",


### PR DESCRIPTION
## Summary

Bumps `expo.version` 1.0.4 → **1.0.5** for the next TestFlight build. Ships everything merged since the 1.0.4 build (#49–#56):

- i18n EN/SV sweep + in-app language switcher
- Extraction: amount estimates, estimated `~` flag, translate-to-app-language, multi-image import
- Legal-screen crash fix + Overview transparent-background fix
- Resend verification code on unverified login
- Account email shown on profile (`/auth/me`)
- Forgot / reset password flow
- Louder prod logging when email delivery fails

EAS auto-increments the iOS build number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)