### PR TITLE
feat(recipes): add a recipe by speaking it (on-device voice)

### DIFF
--- a/apps/expo-app/app.json
+++ b/apps/expo-app/app.json
@@ -54,7 +54,14 @@
       "expo-secure-store",
       "expo-font",
       "expo-web-browser",
-      "expo-localization"
+      "expo-localization",
+      [
+        "expo-speech-recognition",
+        {
+          "microphonePermission": "Allow MealFlow to use the microphone so you can speak a recipe.",
+          "speechRecognitionPermission": "Allow MealFlow to recognize speech so it can turn what you say into a recipe."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/expo-app/app/(app)/recipes/_layout.tsx
+++ b/apps/expo-app/app/(app)/recipes/_layout.tsx
@@ -6,6 +6,7 @@ export default function RecipesLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="new" />
+      <Stack.Screen name="voice" />
       <Stack.Screen name="import" />
       <Stack.Screen name="import/[jobId]" />
       <Stack.Screen name="[id]" />

--- a/apps/expo-app/app/(app)/recipes/voice.tsx
+++ b/apps/expo-app/app/(app)/recipes/voice.tsx
@@ -1,0 +1,3 @@
+import { VoiceRecipeScreen } from '@/src/features/recipes/screens/VoiceRecipeScreen';
+
+export default VoiceRecipeScreen;

--- a/apps/expo-app/package-lock.json
+++ b/apps/expo-app/package-lock.json
@@ -30,6 +30,7 @@
         "expo-localization": "~17.0.9",
         "expo-router": "~6.0.24",
         "expo-secure-store": "~15.0.8",
+        "expo-speech-recognition": "^3.1.3",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
@@ -7430,6 +7431,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-speech-recognition": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.3.tgz",
+      "integrity": "sha512-vluXqggfY2AJcazYITvnV6YSE2rVe5SId5TpdjMC/m6JPUgHCOODrcHJtAQF6OUYl4f2T7oZSceGw6fJCC86Xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/apps/expo-app/package.json
+++ b/apps/expo-app/package.json
@@ -33,6 +33,7 @@
     "expo-localization": "~17.0.9",
     "expo-router": "~6.0.24",
     "expo-secure-store": "~15.0.8",
+    "expo-speech-recognition": "^3.1.3",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-symbols": "~1.0.8",

--- a/apps/expo-app/src/core/navigation/routes.ts
+++ b/apps/expo-app/src/core/navigation/routes.ts
@@ -43,6 +43,7 @@ export const routes = {
       params: { toast },
     }) as Href,
   recipeNew: '/recipes/new' as const,
+  recipeVoice: '/recipes/voice' as Href,
   recipeImport: '/recipes/import' as Href,
   recipeImportReview: (jobId: string, videoUri?: string, videoDurationMs?: number) =>
     ({

--- a/apps/expo-app/src/features/recipes/api/extractionApi.ts
+++ b/apps/expo-app/src/features/recipes/api/extractionApi.ts
@@ -7,6 +7,10 @@ export const extractionApi = {
     return httpClient.appApi.upload<ExtractionJob>(`/api/recipes/extract${query}`, formData);
   },
 
+  startText(transcript: string, locale?: string): Promise<ExtractionJob> {
+    return httpClient.appApi.post<ExtractionJob>('/api/recipes/extract/text', { transcript, locale });
+  },
+
   get(jobId: string): Promise<ExtractionJob> {
     return httpClient.appApi.get<ExtractionJob>(`/api/recipes/extract/${jobId}`);
   },

--- a/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
@@ -33,6 +33,7 @@ export type RecipeExtractionState = {
 export type RecipeExtractionActions = {
   startFromImage: () => Promise<void>;
   startFromVideo: () => Promise<void>;
+  startFromText: (transcript: string) => Promise<void>;
   reset: () => void;
 };
 
@@ -262,6 +263,30 @@ export function useRecipeExtraction(): {
     await startUpload(formData);
   }, [buildFormData, showError, startFromWeb, startUpload, t]);
 
+  const startFromText = useCallback(
+    async (transcript: string) => {
+      setError(null);
+      // No upload phase — the transcript is tiny, so go straight to processing.
+      setPhase('processing');
+      cancelledRef.current = false;
+      try {
+        const created = await extractionApi.startText(transcript, i18n.language);
+        if (cancelledRef.current) return;
+        setJob(created);
+        await beginPolling(created.jobId);
+      } catch (err) {
+        if (cancelledRef.current) return;
+        const apiErr = toApiError(err);
+        const uiErr = mapCommonError(apiErr);
+        const message = apiErr.kind === 'http' && apiErr.detail ? apiErr.detail : uiErr.message;
+        setError(message);
+        setPhase('failed');
+        showError({ kind: uiErr.kind, message });
+      }
+    },
+    [beginPolling, i18n, showError],
+  );
+
   const state = useMemo<RecipeExtractionState>(
     () => ({ phase, job, error, videoUri, videoDurationMs }),
     [phase, job, error, videoUri, videoDurationMs],
@@ -271,9 +296,10 @@ export function useRecipeExtraction(): {
     () => ({
       startFromImage,
       startFromVideo,
+      startFromText,
       reset,
     }),
-    [reset, startFromImage, startFromVideo],
+    [reset, startFromImage, startFromVideo, startFromText],
   );
 
   return { state, actions };

--- a/apps/expo-app/src/features/recipes/hooks/useVoiceCapture.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useVoiceCapture.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ExpoSpeechRecognitionModule,
+  useSpeechRecognitionEvent,
+} from 'expo-speech-recognition';
+
+export type VoiceStatus = 'idle' | 'listening' | 'denied' | 'error';
+
+/**
+ * On-device speech capture for dictating a recipe. Wraps expo-speech-recognition:
+ * request permission → start (continuous, interim results so the transcript grows live) → stop.
+ * The transcript is editable by the caller before it's sent for structuring.
+ */
+export function useVoiceCapture() {
+  const { i18n } = useTranslation();
+  const [status, setStatus] = useState<VoiceStatus>('idle');
+  const [transcript, setTranscript] = useState('');
+
+  useSpeechRecognitionEvent('start', () => setStatus('listening'));
+  useSpeechRecognitionEvent('end', () => setStatus((s) => (s === 'listening' ? 'idle' : s)));
+  useSpeechRecognitionEvent('result', (event) => {
+    const text = event.results?.[0]?.transcript ?? '';
+    if (text) setTranscript(text);
+  });
+  useSpeechRecognitionEvent('error', (event) => {
+    setStatus(event.error === 'not-allowed' ? 'denied' : 'error');
+  });
+
+  const start = useCallback(async () => {
+    const perm = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+    if (!perm.granted) {
+      setStatus('denied');
+      return;
+    }
+    setTranscript('');
+    ExpoSpeechRecognitionModule.start({
+      lang: i18n.language === 'sv' ? 'sv-SE' : 'en-US',
+      interimResults: true,
+      // Keep listening through natural pauses — a recipe is dictated with gaps.
+      continuous: true,
+    });
+  }, [i18n]);
+
+  const stop = useCallback(() => {
+    ExpoSpeechRecognitionModule.stop();
+  }, []);
+
+  const reset = useCallback(() => {
+    ExpoSpeechRecognitionModule.abort();
+    setTranscript('');
+    setStatus('idle');
+  }, []);
+
+  return { status, transcript, setTranscript, start, stop, reset };
+}

--- a/apps/expo-app/src/features/recipes/screens/VoiceRecipeScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/VoiceRecipeScreen.tsx
@@ -1,0 +1,230 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Mic, Sparkles, Square } from 'lucide-react-native';
+import { Button, Screen, TextField } from '@/src/shared/ui';
+import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
+import { useVoiceCapture } from '@/src/features/recipes/hooks/useVoiceCapture';
+import { useRecipeExtraction } from '@/src/features/recipes/hooks';
+import { routes } from '@/src/core/navigation/routes';
+
+export function VoiceRecipeScreen() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = useThemedStyles(createStyles);
+  const voice = useVoiceCapture();
+  const { state, actions } = useRecipeExtraction();
+
+  const isListening = voice.status === 'listening';
+  const isProcessing = state.phase === 'processing' || state.phase === 'uploading';
+  const hasTranscript = voice.transcript.trim().length > 0;
+
+  useEffect(() => {
+    if (state.phase === 'ready' && state.job?.jobId) {
+      router.replace(routes.recipeImportReview(state.job.jobId));
+    }
+  }, [state.phase, state.job?.jobId]);
+
+  const onCreate = async () => {
+    const text = voice.transcript.trim();
+    if (!text) return;
+    await actions.startFromText(text);
+  };
+
+  if (isProcessing) {
+    return (
+      <Screen title={t('recipes.voice.title')} showBack onBack={() => router.back()}>
+        <View style={styles.centered}>
+          <View style={styles.processingIcon}>
+            <Sparkles color={theme.colors.textOnPrimary} size={36} strokeWidth={2.25} />
+          </View>
+          <Text style={styles.processingText}>{t('recipes.voice.building')}</Text>
+          <ActivityIndicator color={theme.colors.primaryDark} />
+        </View>
+      </Screen>
+    );
+  }
+
+  if (voice.status === 'denied') {
+    return (
+      <Screen title={t('recipes.voice.title')} showBack onBack={() => router.back()}>
+        <View style={styles.centered}>
+          <Text style={styles.deniedText}>{t('recipes.voice.permissionDenied')}</Text>
+          <Button
+            title={t('recipes.voice.openSettings')}
+            variant="secondary"
+            onPress={() => Linking.openSettings()}
+          />
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen title={t('recipes.voice.title')} showBack onBack={() => router.back()} scroll>
+      <Text style={styles.hint}>{t('recipes.voice.hint')}</Text>
+
+      <View style={styles.transcriptCard}>
+        {isListening ? (
+          <View style={styles.listeningRow}>
+            <View style={styles.listeningDot} />
+            <Text style={styles.listeningLabel}>{t('recipes.voice.listening')}</Text>
+          </View>
+        ) : null}
+
+        {isListening ? (
+          <Text style={styles.liveText}>
+            {hasTranscript ? voice.transcript : t('recipes.voice.transcriptPlaceholder')}
+          </Text>
+        ) : (
+          <TextField
+            value={voice.transcript}
+            onChangeText={voice.setTranscript}
+            placeholder={t('recipes.voice.transcriptPlaceholder')}
+            multiline
+            numberOfLines={6}
+            textAlignVertical="top"
+            inputStyle={styles.transcriptInput}
+          />
+        )}
+      </View>
+
+      <View style={styles.micWrap}>
+        <Pressable
+          onPress={() => (isListening ? voice.stop() : voice.start())}
+          style={[styles.micButton, isListening ? styles.micButtonActive : null]}
+          accessibilityRole="button"
+          accessibilityLabel={isListening ? t('recipes.voice.tapToStop') : t('recipes.voice.tapToStart')}
+        >
+          {isListening ? (
+            <Square color={theme.colors.error} size={28} strokeWidth={2.5} />
+          ) : (
+            <Mic color={theme.colors.primaryDark} size={28} strokeWidth={2.5} />
+          )}
+        </Pressable>
+        <Text style={styles.micHint}>
+          {isListening ? t('recipes.voice.tapToStop') : t('recipes.voice.tapToStart')}
+        </Text>
+      </View>
+
+      {hasTranscript && !isListening ? (
+        <View style={styles.actions}>
+          <View style={styles.actionRedo}>
+            <Button title={t('recipes.voice.redo')} variant="secondary" onPress={voice.reset} />
+          </View>
+          <View style={styles.actionCreate}>
+            <Button title={t('recipes.voice.createRecipe')} variant="primary" onPress={onCreate} />
+          </View>
+        </View>
+      ) : null}
+    </Screen>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    hint: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: theme.colors.textMuted,
+      lineHeight: 20,
+      marginBottom: theme.spacing.s4,
+    },
+    transcriptCard: {
+      borderWidth: 1,
+      borderColor: theme.colors.borderNeutral,
+      backgroundColor: theme.colors.bgLight,
+      borderRadius: theme.radius.md,
+      padding: theme.spacing.s3,
+      gap: theme.spacing.s2,
+      minHeight: 160,
+    },
+    listeningRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.s2,
+    },
+    listeningDot: {
+      width: 9,
+      height: 9,
+      borderRadius: 5,
+      backgroundColor: theme.colors.error,
+    },
+    listeningLabel: {
+      fontSize: 12,
+      fontWeight: '700',
+      color: theme.colors.error,
+    },
+    liveText: {
+      fontSize: 15,
+      lineHeight: 22,
+      color: theme.colors.text,
+      fontWeight: '500',
+    },
+    transcriptInput: {
+      minHeight: 130,
+    },
+    micWrap: {
+      alignItems: 'center',
+      gap: theme.spacing.s2,
+      marginTop: theme.spacing.s5,
+    },
+    micButton: {
+      width: 76,
+      height: 76,
+      borderRadius: 38,
+      backgroundColor: theme.colors.primaryLight,
+      borderWidth: 1,
+      borderColor: theme.colors.borderGreen,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    micButtonActive: {
+      backgroundColor: theme.colors.errorBg,
+      borderColor: theme.colors.error,
+    },
+    micHint: {
+      fontSize: 12,
+      color: theme.colors.textMuted,
+    },
+    actions: {
+      flexDirection: 'row',
+      gap: theme.spacing.s3,
+      marginTop: theme.spacing.s5,
+    },
+    actionRedo: {
+      flex: 1,
+    },
+    actionCreate: {
+      flex: 2,
+    },
+    centered: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing.s4,
+      paddingVertical: theme.spacing.s6,
+    },
+    processingIcon: {
+      width: 84,
+      height: 84,
+      borderRadius: 26,
+      backgroundColor: theme.colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    processingText: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: theme.colors.text,
+    },
+    deniedText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: theme.colors.textMuted,
+      textAlign: 'center',
+      lineHeight: 22,
+      paddingHorizontal: theme.spacing.s4,
+    },
+  });

--- a/apps/expo-app/src/features/recipes/ui/AddRecipeSheet/AddRecipeSheet.tsx
+++ b/apps/expo-app/src/features/recipes/ui/AddRecipeSheet/AddRecipeSheet.tsx
@@ -1,7 +1,7 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, Image as ImageIcon, PenLine, Video } from 'lucide-react-native';
+import { ChevronRight, Image as ImageIcon, Mic, PenLine, Video } from 'lucide-react-native';
 import { ModalSheet } from '@/src/shared/ui/ModalSheet';
 import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
 import { routes } from '@/src/core/navigation/routes';
@@ -14,7 +14,7 @@ type Props = {
 };
 
 type Row = {
-  key: 'manual' | 'photo' | 'video';
+  key: 'manual' | 'voice' | 'photo' | 'video';
   titleKey: ParseKeys;
   subtitleKey?: ParseKeys;
   icon: (color: string) => React.ReactNode;
@@ -27,6 +27,13 @@ const ROWS: Row[] = [
     titleKey: 'recipes.addRecipeSheet.writeItYourself',
     icon: (color) => <PenLine color={color} size={20} strokeWidth={2.25} />,
     href: routes.recipeNew,
+  },
+  {
+    key: 'voice',
+    titleKey: 'recipes.addRecipeSheet.speakIt',
+    subtitleKey: 'recipes.addRecipeSheet.speakItSubtitle',
+    icon: (color) => <Mic color={color} size={20} strokeWidth={2.25} />,
+    href: routes.recipeVoice,
   },
   {
     key: 'photo',

--- a/apps/expo-app/src/shared/i18n/locales/en.ts
+++ b/apps/expo-app/src/shared/i18n/locales/en.ts
@@ -350,10 +350,27 @@ export const en = {
     addRecipeSheet: {
       title: 'Add a recipe',
       writeItYourself: 'Write it yourself',
+      speakIt: 'Speak it',
+      speakItSubtitle: 'Describe the recipe out loud',
       fromAPhoto: 'From a photo',
       fromAPhotoSubtitle: 'One or more photos of a recipe',
       fromAVideo: 'From a video',
       fromAVideoSubtitle: 'TikTok, Reel or short clip',
+    },
+
+    voice: {
+      title: 'Speak a recipe',
+      hint: 'Say the name, the ingredients, and how to make it. Speak naturally.',
+      tapToStart: 'Tap to start',
+      tapToStop: 'Tap to stop',
+      listening: 'Listening',
+      transcriptPlaceholder: 'What you say will appear here…',
+      redo: 'Redo',
+      createRecipe: 'Create recipe',
+      building: 'Building your recipe…',
+      permissionDenied: 'Microphone or speech access is off. Turn it on in Settings to speak a recipe.',
+      openSettings: 'Open settings',
+      genericError: "We couldn't hear you. Try again.",
     },
 
     thumbnailPicker: {

--- a/apps/expo-app/src/shared/i18n/locales/sv.ts
+++ b/apps/expo-app/src/shared/i18n/locales/sv.ts
@@ -353,10 +353,27 @@ export const sv: Translations = {
     addRecipeSheet: {
       title: 'Lägg till recept',
       writeItYourself: 'Skriv det själv',
+      speakIt: 'Tala in det',
+      speakItSubtitle: 'Beskriv receptet med rösten',
       fromAPhoto: 'Från ett foto',
       fromAPhotoSubtitle: 'Ett eller flera foton av ett recept',
       fromAVideo: 'Från en video',
       fromAVideoSubtitle: 'TikTok, Reel eller kort klipp',
+    },
+
+    voice: {
+      title: 'Tala in ett recept',
+      hint: 'Säg namnet, ingredienserna och hur man gör. Prata som du vill.',
+      tapToStart: 'Tryck för att börja',
+      tapToStop: 'Tryck för att stoppa',
+      listening: 'Lyssnar',
+      transcriptPlaceholder: 'Det du säger dyker upp här…',
+      redo: 'Gör om',
+      createRecipe: 'Skapa recept',
+      building: 'Bygger ditt recept…',
+      permissionDenied: 'Mikrofon- eller talåtkomst är av. Slå på det i Inställningar för att tala in ett recept.',
+      openSettings: 'Öppna inställningar',
+      genericError: 'Vi hörde dig inte. Försök igen.',
     },
 
     thumbnailPicker: {

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/domain/ExtractionSourceType.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/domain/ExtractionSourceType.java
@@ -2,5 +2,6 @@ package com.mealflow.appapi.recipes.extraction.domain;
 
 public enum ExtractionSourceType {
     IMAGE,
-    VIDEO
+    VIDEO,
+    TEXT
 }

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
@@ -103,6 +103,34 @@ public class ExtractionJobProcessor {
         }
     }
 
+    public void processText(String jobId, String transcript, String languageName, String unitSystem) {
+        ExtractionJob job = jobRepository.findById(jobId).orElse(null);
+        if (job == null) {
+            return;
+        }
+        try {
+            RecipeDraft draft = llmExtractor.extractFromText(transcript, languageName, unitSystem);
+            job.setDraft(draft);
+            // No source image for spoken recipes — the user can add a photo on the review screen.
+            job.setStatus(ExtractionStatus.READY);
+            job.setUpdatedAt(clock.instant());
+            jobRepository.save(job);
+        } catch (ExtractionValidationException ex) {
+            job.setStatus(ExtractionStatus.FAILED);
+            job.setErrorCode("VALIDATION");
+            job.setErrorMessage(ex.getMessage());
+            job.setUpdatedAt(clock.instant());
+            jobRepository.save(job);
+        } catch (RuntimeException ex) {
+            log.warn("Text extraction job {} failed: {}", jobId, ex.getMessage(), ex);
+            job.setStatus(ExtractionStatus.FAILED);
+            job.setErrorCode("INTERNAL");
+            job.setErrorMessage("Extraction failed. Please try again.");
+            job.setUpdatedAt(clock.instant());
+            jobRepository.save(job);
+        }
+    }
+
     private String imageMediaType(String contentType) {
         if (contentType == null) {
             return "image/jpeg";

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
@@ -24,9 +24,7 @@ public class LlmRecipeExtractor {
 
     private static final Logger log = LoggerFactory.getLogger(LlmRecipeExtractor.class);
 
-    private static final String SYSTEM_PROMPT = """
-            You are a recipe extractor. The user has provided one or more images from a cooking video or a recipe photo.
-
+    private static final String EXTRACTION_RULES = """
             OUTPUT REQUIREMENTS:
             - All text fields (title, description, ingredient names, steps, category) MUST be in %s, regardless of the source language. Translate if needed.
             - All quantities MUST use the %s system.
@@ -57,6 +55,16 @@ public class LlmRecipeExtractor {
               "languageDetected": string
             }
             """;
+
+    private static final String SYSTEM_PROMPT =
+            "You are a recipe extractor. The user has provided one or more images from a cooking video or a recipe photo.\n\n"
+                    + EXTRACTION_RULES;
+
+    private static final String TEXT_SYSTEM_PROMPT =
+            "You are a recipe extractor. The user dictated a recipe out loud; the text below is a transcript of what they"
+                    + " said. It may be casual and conversational, in any language, and contain filler words or asides —"
+                    + " ignore anything that isn't part of the recipe.\n\n"
+                    + EXTRACTION_RULES;
 
     private final AnthropicClient anthropicClient;
     private final AnthropicProperties anthropicProperties;
@@ -92,6 +100,29 @@ public class LlmRecipeExtractor {
         String text = response.firstText();
         if (text == null || text.isBlank()) {
             throw new ExtractionValidationException("Could not read recipe from media. Try a clearer source.");
+        }
+        return parse(text);
+    }
+
+    public RecipeDraft extractFromText(String transcript, String outputLanguageName, String unitSystem) {
+        if (transcript == null || transcript.isBlank()) {
+            throw new ExtractionValidationException("No transcript to build a recipe from.");
+        }
+
+        List<ContentBlock> userBlocks = List.of(ContentBlock.text("Transcript:\n" + transcript
+                + "\n\nBuild the recipe from this transcript according to the rules. Output JSON only."));
+
+        AnthropicMessageRequest request = new AnthropicMessageRequest(
+                anthropicProperties.getModel(),
+                anthropicProperties.getMaxTokens(),
+                String.format(Locale.ROOT, TEXT_SYSTEM_PROMPT, outputLanguageName, unitSystem),
+                List.of(new AnthropicMessageRequest.Message("user", userBlocks)),
+                0.0);
+
+        AnthropicMessageResponse response = anthropicClient.createMessage(request);
+        String text = response.firstText();
+        if (text == null || text.isBlank()) {
+            throw new ExtractionValidationException("Could not build a recipe from what you said. Try again.");
         }
         return parse(text);
     }

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
@@ -112,6 +112,33 @@ public class RecipeExtractionService {
         return job;
     }
 
+    public ExtractionJob enqueueText(String userId, String transcript, String locale) {
+        if (transcript == null || transcript.isBlank()) {
+            throw new ExtractionValidationException("Please say something to build a recipe from.");
+        }
+        quotaService.enforce(userId);
+
+        ExtractionLocaleResolver.Resolved resolved = localeResolver.resolve(locale);
+
+        ExtractionJob job = new ExtractionJob(
+                userId,
+                ExtractionSourceType.TEXT,
+                ExtractionStatus.PROCESSING,
+                "text/plain",
+                (long) transcript.length(),
+                resolved.languageCode(),
+                resolved.unitSystem(),
+                clock.instant());
+        job = jobRepository.save(job);
+
+        String jobId = job.getId();
+        String text = transcript;
+        String languageName = resolved.languageName();
+        String unitSystem = resolved.unitSystem();
+        extractionExecutor.execute(() -> jobProcessor.processText(jobId, text, languageName, unitSystem));
+        return job;
+    }
+
     public ExtractionJob getJob(String userId, String jobId) {
         return jobRepository
                 .findByIdAndUserId(jobId, userId)

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
@@ -4,6 +4,7 @@ import com.mealflow.appapi.recipes.domain.Recipe;
 import com.mealflow.appapi.recipes.extraction.domain.ExtractionJob;
 import com.mealflow.appapi.recipes.extraction.service.RecipeExtractionService;
 import com.mealflow.appapi.recipes.extraction.web.dto.AcceptExtractionRequest;
+import com.mealflow.appapi.recipes.extraction.web.dto.ExtractTextRequest;
 import com.mealflow.appapi.recipes.extraction.web.dto.ExtractionJobResponse;
 import com.mealflow.appapi.recipes.web.dto.RecipeResponse;
 import com.mealflow.appapi.recipes.web.mapper.RecipeMapper;
@@ -52,6 +53,17 @@ public class ExtractionController {
             Authentication auth) {
         String userId = currentUser.userId(auth);
         ExtractionJob job = service.enqueue(userId, files, locale);
+        ExtractionJobResponse response = extractionMapper.toResponse(job);
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .location(URI.create("/api/recipes/extract/" + job.getId()))
+                .body(response);
+    }
+
+    @PostMapping("/text")
+    public ResponseEntity<ExtractionJobResponse> createFromText(
+            @Valid @RequestBody ExtractTextRequest body, Authentication auth) {
+        String userId = currentUser.userId(auth);
+        ExtractionJob job = service.enqueueText(userId, body.transcript(), body.locale());
         ExtractionJobResponse response = extractionMapper.toResponse(job);
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .location(URI.create("/api/recipes/extract/" + job.getId()))

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/ExtractTextRequest.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/ExtractTextRequest.java
@@ -1,0 +1,7 @@
+package com.mealflow.appapi.recipes.extraction.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** Body for POST /api/recipes/extract/text — a spoken/typed recipe transcript. */
+public record ExtractTextRequest(@NotBlank @Size(max = 5000) String transcript, String locale) {}


### PR DESCRIPTION
## Summary

New **"Speak it"** option in the add-recipe sheet: tap to dictate a recipe out loud, watch the transcript build live, edit it if a word was misheard, then let the LLM structure it — feeding into the **same review/accept flow** as photo/video.

### How it works
Voice → text (on-device, free) → the existing extraction LLM structures the transcript → `RecipeDraft` → review screen. So `1 kg nötfärs, 8 tortillabröd…` becomes a proper recipe (title, ingredients, `~`-flagged estimates, translated to the app language).

## Frontend
- `expo-speech-recognition@3.1.3` (SDK-54 line) for on-device transcription; config plugin + `NSMicrophoneUsageDescription` / `NSSpeechRecognitionUsageDescription` in `app.json`.
- `useVoiceCapture` (permission → start/stop → live transcript, `sv-SE`/`en-US` from the app language), `VoiceRecipeScreen` (record → **editable transcript** → create), a new `AddRecipeSheet` row (2nd, after "Write it yourself"), route, EN/SV copy.
- `useRecipeExtraction.startFromText` + `extractionApi.startText`.

## Backend (reuses the pipeline)
- `POST /api/recipes/extract/text { transcript, locale }` → `LlmRecipeExtractor.extractFromText` (shared rules, text-oriented prompt) → `RecipeDraft`, via a new `TEXT` source type + text job path. **No media, no vision tokens** — a cheap text-only call.

## Cost
Negligible — on-device STT is free; structuring is a small text LLM call (~1 öre), cheaper than photo/video extraction.

## Verification
- Backend: compiles, `spotless:check` clean, `LlmRecipeExtractorTest` + `ExtractionControllerIT` green.
- Frontend: `tsc --noEmit` at baseline (no new errors), `eslint` clean, `expo config` resolves the plugin + injects the iOS permission strings.

## ⚠️ Testing / rollout
Adds a **native module**, so it needs a fresh **dev-client build** to run (`eas build --profile development`) and ships to users with the next production build. CI doesn't build the app, so the checks here cover backend + e2e only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)