### PR TITLE
chore(release): bump app version to 1.0.6

### DIFF
--- a/apps/expo-app/app.json
+++ b/apps/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "MealFlow",
     "slug": "mealflow",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "orientation": "portrait",
     "icon": "./assets/icons/mealflow_icon_1024.png",
     "scheme": "mealflow",


### PR DESCRIPTION
## Summary

Bumps `expo.version` 1.0.5 → **1.0.6** to ship the **on-device voice recipe** feature (#58) to TestFlight. EAS auto-increments the iOS build number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)