### PR TITLE
feat(recipes): find a recipe by name

### DIFF
--- a/apps/expo-app/app/(app)/recipes/_layout.tsx
+++ b/apps/expo-app/app/(app)/recipes/_layout.tsx
@@ -7,6 +7,7 @@ export default function RecipesLayout() {
       <Stack.Screen name="index" />
       <Stack.Screen name="new" />
       <Stack.Screen name="voice" />
+      <Stack.Screen name="search" />
       <Stack.Screen name="import" />
       <Stack.Screen name="import/[jobId]" />
       <Stack.Screen name="[id]" />

--- a/apps/expo-app/app/(app)/recipes/search.tsx
+++ b/apps/expo-app/app/(app)/recipes/search.tsx
@@ -1,0 +1,3 @@
+import { SearchRecipeScreen } from '@/src/features/recipes/screens/SearchRecipeScreen';
+
+export default SearchRecipeScreen;

--- a/apps/expo-app/src/core/navigation/routes.ts
+++ b/apps/expo-app/src/core/navigation/routes.ts
@@ -44,6 +44,7 @@ export const routes = {
     }) as Href,
   recipeNew: '/recipes/new' as const,
   recipeVoice: '/recipes/voice' as Href,
+  recipeSearch: '/recipes/search' as Href,
   recipeImport: '/recipes/import' as Href,
   recipeImportReview: (jobId: string, videoUri?: string, videoDurationMs?: number) =>
     ({

--- a/apps/expo-app/src/features/recipes/api/extractionApi.ts
+++ b/apps/expo-app/src/features/recipes/api/extractionApi.ts
@@ -11,6 +11,10 @@ export const extractionApi = {
     return httpClient.appApi.post<ExtractionJob>('/api/recipes/extract/text', { transcript, locale });
   },
 
+  startSearch(query: string, locale?: string): Promise<ExtractionJob> {
+    return httpClient.appApi.post<ExtractionJob>('/api/recipes/extract/search', { query, locale });
+  },
+
   get(jobId: string): Promise<ExtractionJob> {
     return httpClient.appApi.get<ExtractionJob>(`/api/recipes/extract/${jobId}`);
   },

--- a/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
+++ b/apps/expo-app/src/features/recipes/hooks/useRecipeExtraction.ts
@@ -34,6 +34,7 @@ export type RecipeExtractionActions = {
   startFromImage: () => Promise<void>;
   startFromVideo: () => Promise<void>;
   startFromText: (transcript: string) => Promise<void>;
+  startFromSearch: (query: string) => Promise<void>;
   reset: () => void;
 };
 
@@ -287,6 +288,29 @@ export function useRecipeExtraction(): {
     [beginPolling, i18n, showError],
   );
 
+  const startFromSearch = useCallback(
+    async (query: string) => {
+      setError(null);
+      setPhase('processing');
+      cancelledRef.current = false;
+      try {
+        const created = await extractionApi.startSearch(query, i18n.language);
+        if (cancelledRef.current) return;
+        setJob(created);
+        await beginPolling(created.jobId);
+      } catch (err) {
+        if (cancelledRef.current) return;
+        const apiErr = toApiError(err);
+        const uiErr = mapCommonError(apiErr);
+        const message = apiErr.kind === 'http' && apiErr.detail ? apiErr.detail : uiErr.message;
+        setError(message);
+        setPhase('failed');
+        showError({ kind: uiErr.kind, message });
+      }
+    },
+    [beginPolling, i18n, showError],
+  );
+
   const state = useMemo<RecipeExtractionState>(
     () => ({ phase, job, error, videoUri, videoDurationMs }),
     [phase, job, error, videoUri, videoDurationMs],
@@ -297,9 +321,10 @@ export function useRecipeExtraction(): {
       startFromImage,
       startFromVideo,
       startFromText,
+      startFromSearch,
       reset,
     }),
-    [reset, startFromImage, startFromVideo, startFromText],
+    [reset, startFromImage, startFromVideo, startFromText, startFromSearch],
   );
 
   return { state, actions };

--- a/apps/expo-app/src/features/recipes/screens/SearchRecipeScreen.tsx
+++ b/apps/expo-app/src/features/recipes/screens/SearchRecipeScreen.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Info, Sparkles } from 'lucide-react-native';
+import { Button, Screen, TextField } from '@/src/shared/ui';
+import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
+import { useRecipeExtraction } from '@/src/features/recipes/hooks';
+import { routes } from '@/src/core/navigation/routes';
+
+export function SearchRecipeScreen() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = useThemedStyles(createStyles);
+  const { state, actions } = useRecipeExtraction();
+  const [query, setQuery] = useState('');
+
+  const isSearching = state.phase === 'processing' || state.phase === 'uploading';
+  const canSearch = query.trim().length > 1 && !isSearching;
+
+  useEffect(() => {
+    if (state.phase === 'ready' && state.job?.jobId) {
+      router.replace(routes.recipeImportReview(state.job.jobId));
+    }
+  }, [state.phase, state.job?.jobId]);
+
+  const onSearch = async () => {
+    if (!canSearch) return;
+    await actions.startFromSearch(query.trim());
+  };
+
+  if (isSearching) {
+    return (
+      <Screen title={t('recipes.search.title')} showBack onBack={() => router.back()}>
+        <View style={styles.centered}>
+          <View style={styles.processingIcon}>
+            <Sparkles color={theme.colors.textOnPrimary} size={36} strokeWidth={2.25} />
+          </View>
+          <Text style={styles.processingText}>{t('recipes.search.searching')}</Text>
+          <ActivityIndicator color={theme.colors.primaryDark} />
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen title={t('recipes.search.title')} showBack onBack={() => router.back()} scroll>
+      <Text style={styles.hint}>{t('recipes.search.hint')}</Text>
+
+      <TextField
+        label={t('recipes.search.dishLabel')}
+        value={query}
+        onChangeText={setQuery}
+        placeholder={t('recipes.search.placeholder')}
+        autoCapitalize="sentences"
+        returnKeyType="search"
+        onSubmitEditing={onSearch}
+      />
+
+      {state.phase === 'failed' && state.error ? (
+        <Text style={styles.error}>{state.error}</Text>
+      ) : null}
+
+      <View style={styles.action}>
+        <Button
+          title={t('recipes.search.cta')}
+          variant="primary"
+          onPress={onSearch}
+          disabled={!canSearch}
+        />
+      </View>
+
+      <View style={styles.disclaimer}>
+        <Info color={theme.colors.textMuted} size={14} strokeWidth={2.4} />
+        <Text style={styles.disclaimerText}>{t('recipes.search.disclaimer')}</Text>
+      </View>
+    </Screen>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    hint: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: theme.colors.textMuted,
+      lineHeight: 20,
+      marginBottom: theme.spacing.s4,
+    },
+    action: {
+      marginTop: theme.spacing.s4,
+    },
+    error: {
+      color: theme.colors.error,
+      fontSize: 13,
+      fontWeight: '600',
+      marginTop: theme.spacing.s2,
+    },
+    disclaimer: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: theme.spacing.s2,
+      marginTop: theme.spacing.s5,
+    },
+    disclaimerText: {
+      flex: 1,
+      fontSize: 12,
+      color: theme.colors.textMuted,
+      lineHeight: 17,
+    },
+    centered: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing.s4,
+      paddingVertical: theme.spacing.s6,
+    },
+    processingIcon: {
+      width: 84,
+      height: 84,
+      borderRadius: 26,
+      backgroundColor: theme.colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    processingText: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: theme.colors.text,
+    },
+  });

--- a/apps/expo-app/src/features/recipes/ui/AddRecipeSheet/AddRecipeSheet.tsx
+++ b/apps/expo-app/src/features/recipes/ui/AddRecipeSheet/AddRecipeSheet.tsx
@@ -1,7 +1,7 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, Image as ImageIcon, Mic, PenLine, Video } from 'lucide-react-native';
+import { ChevronRight, Image as ImageIcon, Mic, PenLine, Search, Video } from 'lucide-react-native';
 import { ModalSheet } from '@/src/shared/ui/ModalSheet';
 import { type Theme, useTheme, useThemedStyles } from '@/src/shared/theme';
 import { routes } from '@/src/core/navigation/routes';
@@ -14,7 +14,7 @@ type Props = {
 };
 
 type Row = {
-  key: 'manual' | 'voice' | 'photo' | 'video';
+  key: 'manual' | 'voice' | 'search' | 'photo' | 'video';
   titleKey: ParseKeys;
   subtitleKey?: ParseKeys;
   icon: (color: string) => React.ReactNode;
@@ -34,6 +34,13 @@ const ROWS: Row[] = [
     subtitleKey: 'recipes.addRecipeSheet.speakItSubtitle',
     icon: (color) => <Mic color={color} size={20} strokeWidth={2.25} />,
     href: routes.recipeVoice,
+  },
+  {
+    key: 'search',
+    titleKey: 'recipes.addRecipeSheet.searchForIt',
+    subtitleKey: 'recipes.addRecipeSheet.searchForItSubtitle',
+    icon: (color) => <Search color={color} size={20} strokeWidth={2.25} />,
+    href: routes.recipeSearch,
   },
   {
     key: 'photo',

--- a/apps/expo-app/src/shared/i18n/locales/en.ts
+++ b/apps/expo-app/src/shared/i18n/locales/en.ts
@@ -352,10 +352,23 @@ export const en = {
       writeItYourself: 'Write it yourself',
       speakIt: 'Speak it',
       speakItSubtitle: 'Describe the recipe out loud',
+      searchForIt: 'Search for it',
+      searchForItSubtitle: 'Find a dish by name',
       fromAPhoto: 'From a photo',
       fromAPhotoSubtitle: 'One or more photos of a recipe',
       fromAVideo: 'From a video',
       fromAVideoSubtitle: 'TikTok, Reel or short clip',
+    },
+
+    search: {
+      title: 'Search for a recipe',
+      hint: 'Heard about a dish somewhere? Type its name and we\'ll write the recipe for it.',
+      dishLabel: 'Dish name',
+      placeholder: 'e.g. Marry Me Chicken',
+      cta: 'Find recipe',
+      searching: 'Looking up the recipe…',
+      disclaimer:
+        'Written by AI from what it knows about the dish — amounts are estimates, so check them before saving.',
     },
 
     voice: {

--- a/apps/expo-app/src/shared/i18n/locales/sv.ts
+++ b/apps/expo-app/src/shared/i18n/locales/sv.ts
@@ -355,10 +355,23 @@ export const sv: Translations = {
       writeItYourself: 'Skriv det själv',
       speakIt: 'Tala in det',
       speakItSubtitle: 'Beskriv receptet med rösten',
+      searchForIt: 'Sök efter det',
+      searchForItSubtitle: 'Hitta en maträtt på namn',
       fromAPhoto: 'Från ett foto',
       fromAPhotoSubtitle: 'Ett eller flera foton av ett recept',
       fromAVideo: 'Från en video',
       fromAVideoSubtitle: 'TikTok, Reel eller kort klipp',
+    },
+
+    search: {
+      title: 'Sök efter ett recept',
+      hint: 'Hört talas om en maträtt? Skriv namnet så skriver vi receptet åt dig.',
+      dishLabel: 'Maträttens namn',
+      placeholder: 't.ex. Marry Me Chicken',
+      cta: 'Hitta recept',
+      searching: 'Letar upp receptet…',
+      disclaimer:
+        'Skrivet av AI utifrån vad den känner till om rätten — mängderna är uppskattningar, så kontrollera dem innan du sparar.',
     },
 
     voice: {

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/ExtractionJobProcessor.java
@@ -9,6 +9,7 @@ import com.mealflow.appapi.recipes.image.ImageKitUploadResult;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.List;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -104,14 +105,25 @@ public class ExtractionJobProcessor {
     }
 
     public void processText(String jobId, String transcript, String languageName, String unitSystem) {
+        runDraftJob(jobId, () -> llmExtractor.extractFromText(transcript, languageName, unitSystem));
+    }
+
+    public void processSearch(String jobId, String dishName, String languageName, String unitSystem) {
+        runDraftJob(jobId, () -> llmExtractor.searchByName(dishName, languageName, unitSystem));
+    }
+
+    /**
+     * Shared job handling for the media-less sources (spoken and searched recipes): build the draft,
+     * mark the job ready, and record a failure the review screen can show. There is no source image
+     * for these — the user can add a photo on the review screen.
+     */
+    private void runDraftJob(String jobId, Supplier<RecipeDraft> draftSupplier) {
         ExtractionJob job = jobRepository.findById(jobId).orElse(null);
         if (job == null) {
             return;
         }
         try {
-            RecipeDraft draft = llmExtractor.extractFromText(transcript, languageName, unitSystem);
-            job.setDraft(draft);
-            // No source image for spoken recipes — the user can add a photo on the review screen.
+            job.setDraft(draftSupplier.get());
             job.setStatus(ExtractionStatus.READY);
             job.setUpdatedAt(clock.instant());
             jobRepository.save(job);
@@ -122,7 +134,7 @@ public class ExtractionJobProcessor {
             job.setUpdatedAt(clock.instant());
             jobRepository.save(job);
         } catch (RuntimeException ex) {
-            log.warn("Text extraction job {} failed: {}", jobId, ex.getMessage(), ex);
+            log.warn("Extraction job {} failed: {}", jobId, ex.getMessage(), ex);
             job.setStatus(ExtractionStatus.FAILED);
             job.setErrorCode("INTERNAL");
             job.setErrorMessage("Extraction failed. Please try again.");

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/LlmRecipeExtractor.java
@@ -60,6 +60,18 @@ public class LlmRecipeExtractor {
             "You are a recipe extractor. The user has provided one or more images from a cooking video or a recipe photo.\n\n"
                     + EXTRACTION_RULES;
 
+    private static final String SEARCH_SYSTEM_PROMPT =
+            "You are a recipe reference. The user names a dish they want to cook — you write the recipe"
+                    + " for it from what you know about that dish.\n\n"
+                    + "Write the version a home cook would recognise as the classic take on it. If the name is"
+                    + " ambiguous, pick the most widely known dish by that name. If you don't actually know the"
+                    + " dish, do NOT invent one: return a title of \"\" and empty ingredients and steps.\n\n"
+                    + "Because you are recalling this rather than reading it from a source, treat every quantity"
+                    + " as an estimate: set \"estimated\" to true on every ingredient and list each ingredient"
+                    + " name, plus 'cookingTimeMinutes' and 'portions', in uncertainFields. The user reviews and"
+                    + " corrects the result before saving.\n\n"
+                    + EXTRACTION_RULES;
+
     private static final String TEXT_SYSTEM_PROMPT =
             "You are a recipe extractor. The user dictated a recipe out loud; the text below is a transcript of what they"
                     + " said. It may be casual and conversational, in any language, and contain filler words or asides —"
@@ -125,6 +137,39 @@ public class LlmRecipeExtractor {
             throw new ExtractionValidationException("Could not build a recipe from what you said. Try again.");
         }
         return parse(text);
+    }
+
+    /**
+     * Write the recipe for a dish the user named. The model recalls it rather than reading a source,
+     * so the prompt marks every amount as estimated — the review screen then flags them for the user.
+     */
+    public RecipeDraft searchByName(String dishName, String outputLanguageName, String unitSystem) {
+        if (dishName == null || dishName.isBlank()) {
+            throw new ExtractionValidationException("Enter a dish to search for.");
+        }
+
+        List<ContentBlock> userBlocks = List.of(ContentBlock.text(
+                "Dish: " + dishName + "\n\nWrite the recipe for this dish according to the rules. Output JSON only."));
+
+        AnthropicMessageRequest request = new AnthropicMessageRequest(
+                anthropicProperties.getModel(),
+                anthropicProperties.getMaxTokens(),
+                String.format(Locale.ROOT, SEARCH_SYSTEM_PROMPT, outputLanguageName, unitSystem),
+                List.of(new AnthropicMessageRequest.Message("user", userBlocks)),
+                0.0);
+
+        AnthropicMessageResponse response = anthropicClient.createMessage(request);
+        String text = response.firstText();
+        if (text == null || text.isBlank()) {
+            throw new ExtractionValidationException("Could not find that recipe. Try another name.");
+        }
+        try {
+            return parse(text);
+        } catch (ExtractionValidationException ex) {
+            // parse() rejects a blank title, which is exactly how the prompt says
+            // "I don't know this dish" — surface that as a search miss, not a parse failure.
+            throw new ExtractionValidationException("Could not find that recipe. Try another name.");
+        }
     }
 
     public RecipeDraft parse(String text) {

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/service/RecipeExtractionService.java
@@ -139,6 +139,34 @@ public class RecipeExtractionService {
         return job;
     }
 
+    /** Look up a dish by name and let the model write the recipe for it. */
+    public ExtractionJob enqueueSearch(String userId, String query, String locale) {
+        if (query == null || query.isBlank()) {
+            throw new ExtractionValidationException("Enter a dish to search for.");
+        }
+        quotaService.enforce(userId);
+
+        ExtractionLocaleResolver.Resolved resolved = localeResolver.resolve(locale);
+
+        ExtractionJob job = new ExtractionJob(
+                userId,
+                ExtractionSourceType.TEXT,
+                ExtractionStatus.PROCESSING,
+                "text/plain",
+                (long) query.length(),
+                resolved.languageCode(),
+                resolved.unitSystem(),
+                clock.instant());
+        job = jobRepository.save(job);
+
+        String jobId = job.getId();
+        String dishName = query.trim();
+        String languageName = resolved.languageName();
+        String unitSystem = resolved.unitSystem();
+        extractionExecutor.execute(() -> jobProcessor.processSearch(jobId, dishName, languageName, unitSystem));
+        return job;
+    }
+
     public ExtractionJob getJob(String userId, String jobId) {
         return jobRepository
                 .findByIdAndUserId(jobId, userId)

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/ExtractionController.java
@@ -6,6 +6,7 @@ import com.mealflow.appapi.recipes.extraction.service.RecipeExtractionService;
 import com.mealflow.appapi.recipes.extraction.web.dto.AcceptExtractionRequest;
 import com.mealflow.appapi.recipes.extraction.web.dto.ExtractTextRequest;
 import com.mealflow.appapi.recipes.extraction.web.dto.ExtractionJobResponse;
+import com.mealflow.appapi.recipes.extraction.web.dto.SearchRecipeRequest;
 import com.mealflow.appapi.recipes.web.dto.RecipeResponse;
 import com.mealflow.appapi.recipes.web.mapper.RecipeMapper;
 import com.mealflow.appapi.security.config.CurrentUser;
@@ -64,6 +65,17 @@ public class ExtractionController {
             @Valid @RequestBody ExtractTextRequest body, Authentication auth) {
         String userId = currentUser.userId(auth);
         ExtractionJob job = service.enqueueText(userId, body.transcript(), body.locale());
+        ExtractionJobResponse response = extractionMapper.toResponse(job);
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .location(URI.create("/api/recipes/extract/" + job.getId()))
+                .body(response);
+    }
+
+    @PostMapping("/search")
+    public ResponseEntity<ExtractionJobResponse> createFromSearch(
+            @Valid @RequestBody SearchRecipeRequest body, Authentication auth) {
+        String userId = currentUser.userId(auth);
+        ExtractionJob job = service.enqueueSearch(userId, body.query(), body.locale());
         ExtractionJobResponse response = extractionMapper.toResponse(job);
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .location(URI.create("/api/recipes/extract/" + job.getId()))

--- a/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/SearchRecipeRequest.java
+++ b/services/app-api/src/main/java/com/mealflow/appapi/recipes/extraction/web/dto/SearchRecipeRequest.java
@@ -1,0 +1,7 @@
+package com.mealflow.appapi.recipes.extraction.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** Body for POST /api/recipes/extract/search — the name of a dish to write a recipe for. */
+public record SearchRecipeRequest(@NotBlank @Size(max = 120) String query, String locale) {}


### PR DESCRIPTION
## Summary

New **"Search for it"** entry in the add-recipe sheet: type a dish you heard about — *"Marry Me Chicken"* — and the model writes the recipe for it. It lands in the **same review/accept flow** as photo, video and voice.

Five ways to add a recipe now: write it · speak it · **search for it** · from a photo · from a video.

## How it's built
Reuses the media-less extraction path built for voice — **only the prompt is new**.

- Backend: `POST /api/recipes/extract/search` → `LlmRecipeExtractor.searchByName()`.
- `processText` / `processSearch` now share one `runDraftJob()` helper instead of duplicating ~25 lines of job/error handling.

## Guarding against invented recipes
This is the real risk with recall-based generation, so there are two guards:

1. **The model is allowed to say "I don't know."** The prompt tells it to return an empty title rather than invent a dish it doesn't recognise. `parse()` rejects a blank title, and that's caught and surfaced as *"Could not find that recipe. Try another name."* — instead of a plausible-looking fake.
2. **Everything is marked as an estimate.** Every ingredient gets `estimated: true` and lands in `uncertainFields`, so the **existing** `~` prefix and review banner flag the whole recipe for checking — no new UI needed. The search screen also states up front that this is AI-written and amounts should be checked.

## Cost
A plain text call, ~1 öre. No images, no web fetching, no search API.

## Verification
- Backend: compiles, `spotless:check` clean, `LlmRecipeExtractorTest` (6) + `ExtractionControllerIT` (7) green.
- Frontend: `tsc --noEmit` at the pre-existing baseline (no new errors), `eslint` clean.

## Note
Searched recipes get **no image** (same as voice) — the user can add one on the review screen. Worth revisiting if it feels lacking next to the photo/video flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)